### PR TITLE
created scheduling actions

### DIFF
--- a/app/scheduling/actions.ts
+++ b/app/scheduling/actions.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { eq } from "drizzle-orm";
+import { eq,and } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "@/lib/db";
 import { coachingSessions } from "@/lib/db/schema";
@@ -13,7 +13,7 @@ export type SchedulingActionState = {
    message?: string;
 } | null;
 
-const iso8601 = z.string().datetime({ message: "Must be an ISO 8601 datetime" });
+const iso8601 = z.string().datetime({offset: true, message: "Must be an ISO 8601 datetime with timezone"});
 
 const timeSlotSchema = z
    .object({
@@ -28,7 +28,8 @@ const selectAvailabilitiesSchema = z.object({
    session_id: z.string().uuid("Invalid session ID"),
    time_slots: z
       .array(timeSlotSchema)
-      .min(1, "At least one time slot is required"),
+      .min(1, "At least one time slot is required")
+      .max(20,"You can select up to 20 time slots")
 });
 
 const selectTimeSlotSchema = z.object({
@@ -79,10 +80,28 @@ async function getAuthorizedSession(
    return { ok: true, session };
 }
 
+
+function parseJsonField<T>(formData: FormData, key:string): T | null {
+   const value = formData.get(key);
+   if (typeof value !== "string") return null;
+   try {
+      return JSON.parse(value) as T;
+   } catch {
+      return null
+   }
+}
+
+function normalizeSlots(slot: TimeSlot): TimeSlot {
+   return {
+      start: new Date(slot.start).toISOString(),
+      end: new Date(slot.end).toISOString()
+   }
+}
+
+
 /**
  * Set (or replace) the available time slots on an existing coaching session.
  *
- * Both the assigned coach and the session user can call this action.
  * The payload is an array of `{ start, end }` ISO 8601 strings.
  */
 export async function selectAvailabilities(
@@ -96,29 +115,35 @@ export async function selectAvailabilities(
    }
 
    // 2. Parse & validate input
-   let sessionId: string;
-   let timeSlots: TimeSlot[];
-   try {
-      const rawSlots = formData.get("time_slots")?.toString() ?? "";
-      const parsed = selectAvailabilitiesSchema.safeParse({
-         session_id: formData.get("session_id")?.toString(),
-         time_slots: JSON.parse(rawSlots),
-      });
-
-      if (!parsed.success) {
-         return { errors: parsed.error.flatten().fieldErrors };
-      }
-
-      sessionId = parsed.data.session_id;
-      timeSlots = parsed.data.time_slots as TimeSlot[];
-   } catch {
-      return { errors: { time_slots: ["Invalid time slots format"] } };
+   const rawTimeSlots = parseJsonField<TimeSlot[]>(formData, "time_slots");
+   if (!rawTimeSlots) {
+      return {errors: {time_slots: ["Invalid time slots format"]}};
    }
+
+   const parsed = selectAvailabilitiesSchema.safeParse({
+      session_id: formData.get("session_id")?.toString(),
+      time_slots: rawTimeSlots
+   })
+
+   if (!parsed.success) {
+      return {errors: parsed.error.flatten().fieldErrors}
+   }
+
+   const sessionId = parsed.data.session_id;
+   const timeSlots = parsed.data.time_slots.map(normalizeSlots)
 
    // 3. Authorization: caller must be the coach or user on this session
    const result = await getAuthorizedSession(sessionId, callerId);
    if (!result.ok) {
       return result.state;
+   }
+
+   if (result.session.coachId !== callerId) {
+      return {
+         errors: {
+            _form: ["Only the coach can set availabilities"]
+         }
+      }
    }
 
    // 4. Only pending sessions can have their availabilities changed
@@ -140,14 +165,10 @@ export async function selectAvailabilities(
          })
          .where(eq(coachingSessions.id, sessionId));
    } catch (e) {
-      console.error(e);
+      console.error("[SELECT_AVAILABILITIES]", e);
       return {
          errors: {
-            _form: [
-               e instanceof Error
-                  ? e.message
-                  : "Could not update availabilities",
-            ],
+            _form: ["Could not update availabilities"],
          },
       };
    }
@@ -183,7 +204,8 @@ export async function selectTimeSlot(
       return { errors: parsed.error.flatten().fieldErrors };
    }
 
-   const { session_id, start, end } = parsed.data;
+   const { session_id} = parsed.data;
+   const {start, end} = normalizeSlots({start: parsed.data.start, end: parsed.data.end})
 
    // 3. Authorization
    const result = await getAuthorizedSession(session_id, callerId);
@@ -192,6 +214,14 @@ export async function selectTimeSlot(
    }
 
    const { session } = result;
+
+   if (session.userId !== callerId) {
+      return {
+         errors:{
+            _form: ["Only the user can select a time slot"]
+         }
+      }
+   }
 
    // 4. Only pending sessions can be confirmed
    if (session.status !== "pending") {
@@ -227,23 +257,33 @@ export async function selectTimeSlot(
 
    // 5. Confirm the session with the chosen slot
    try {
-      await db
+      const updatedRows = await db
          .update(coachingSessions)
          .set({
             scheduledAt: new Date(start),
             status: "confirmed",
             updatedAt: new Date(),
          })
-         .where(eq(coachingSessions.id, session_id));
+         .where(
+            and(
+               eq(coachingSessions.id, session_id),
+               eq(coachingSessions.status, "pending"),
+            ),
+         )
+         .returning({ id: coachingSessions.id });
+
+      if (updatedRows.length === 0) {
+         return {
+            errors: {
+               _form: ["This session is no longer available for confirmation"],
+            },
+         };
+      }
    } catch (e) {
-      console.error(e);
+      console.error("[SELECT_TIME_SLOT]", e);
       return {
          errors: {
-            _form: [
-               e instanceof Error
-                  ? e.message
-                  : "Could not confirm the time slot",
-            ],
+            _form: ["Could not confirm the time slot"],
          },
       };
    }

--- a/app/scheduling/actions.ts
+++ b/app/scheduling/actions.ts
@@ -29,7 +29,7 @@ const selectAvailabilitiesSchema = z.object({
    time_slots: z
       .array(timeSlotSchema)
       .min(1, "At least one time slot is required")
-      .max(20,"You can select up to 20 time slots")
+      .max(50,"You can select up to 50 time slots")
 });
 
 const selectTimeSlotSchema = z.object({
@@ -138,14 +138,6 @@ export async function selectAvailabilities(
       return result.state;
    }
 
-   if (result.session.coachId !== callerId) {
-      return {
-         errors: {
-            _form: ["Only the coach can set availabilities"]
-         }
-      }
-   }
-
    // 4. Only pending sessions can have their availabilities changed
    if (result.session.status !== "pending") {
       return {
@@ -214,14 +206,6 @@ export async function selectTimeSlot(
    }
 
    const { session } = result;
-
-   if (session.userId !== callerId) {
-      return {
-         errors:{
-            _form: ["Only the user can select a time slot"]
-         }
-      }
-   }
 
    // 4. Only pending sessions can be confirmed
    if (session.status !== "pending") {

--- a/app/scheduling/actions.ts
+++ b/app/scheduling/actions.ts
@@ -121,7 +121,16 @@ export async function selectAvailabilities(
       return result.state;
    }
 
-   // 4. Update the session
+   // 4. Only pending sessions can have their availabilities changed
+   if (result.session.status !== "pending") {
+      return {
+         errors: {
+            _form: ["Availabilities can only be set for pending sessions"],
+         },
+      };
+   }
+
+   // 5. Update the session
    try {
       await db
          .update(coachingSessions)
@@ -184,7 +193,16 @@ export async function selectTimeSlot(
 
    const { session } = result;
 
-   // 4. Verify the slot exists in the session's available time slots
+   // 4. Only pending sessions can be confirmed
+   if (session.status !== "pending") {
+      return {
+         errors: {
+            _form: ["Only pending sessions can be confirmed"],
+         },
+      };
+   }
+
+   // 5. Verify the slot exists in the session's available time slots
    const slots = session.selectedTimeSlots as TimeSlot[] | null;
    if (!slots || !Array.isArray(slots)) {
       return {

--- a/app/scheduling/actions.ts
+++ b/app/scheduling/actions.ts
@@ -1,0 +1,234 @@
+"use server";
+
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "@/lib/db";
+import { coachingSessions } from "@/lib/db/schema";
+import { createClient } from "@/utils/supabase/server";
+
+export type TimeSlot = { start: string; end: string };
+
+export type SchedulingActionState = {
+   errors?: Record<string, string[]>;
+   message?: string;
+} | null;
+
+const iso8601 = z.string().datetime({ message: "Must be an ISO 8601 datetime" });
+
+const timeSlotSchema = z
+   .object({
+      start: iso8601,
+      end: iso8601,
+   })
+   .refine((slot) => new Date(slot.end) > new Date(slot.start), {
+      message: "End time must be after start time",
+   });
+
+const selectAvailabilitiesSchema = z.object({
+   session_id: z.string().uuid("Invalid session ID"),
+   time_slots: z
+      .array(timeSlotSchema)
+      .min(1, "At least one time slot is required"),
+});
+
+const selectTimeSlotSchema = z.object({
+   session_id: z.string().uuid("Invalid session ID"),
+   start: iso8601,
+   end: iso8601,
+});
+
+async function getAuthenticatedUserId(): Promise<string | null> {
+   const supabase = await createClient();
+   const {
+      data: { user },
+   } = await supabase.auth.getUser();
+   return user?.id ?? null;
+}
+
+/**
+ * Fetch a coaching session and verify the caller is either the coach or user.
+ * Returns the session row or an error state.
+ */
+async function getAuthorizedSession(
+   sessionId: string,
+   userId: string,
+): Promise<
+   | { ok: true; session: typeof coachingSessions.$inferSelect }
+   | { ok: false; state: SchedulingActionState }
+> {
+   const [session] = await db
+      .select()
+      .from(coachingSessions)
+      .where(eq(coachingSessions.id, sessionId))
+      .limit(1);
+
+   if (!session) {
+      return {
+         ok: false,
+         state: { errors: { _form: ["Coaching session not found"] } },
+      };
+   }
+
+   if (session.coachId !== userId && session.userId !== userId) {
+      return {
+         ok: false,
+         state: { errors: { _form: ["You are not authorized to modify this session"] } },
+      };
+   }
+
+   return { ok: true, session };
+}
+
+/**
+ * Set (or replace) the available time slots on an existing coaching session.
+ *
+ * Both the assigned coach and the session user can call this action.
+ * The payload is an array of `{ start, end }` ISO 8601 strings.
+ */
+export async function selectAvailabilities(
+   _prev: SchedulingActionState,
+   formData: FormData,
+): Promise<SchedulingActionState> {
+   // 1. Auth gate
+   const callerId = await getAuthenticatedUserId();
+   if (!callerId) {
+      return { errors: { _form: ["You must be logged in"] } };
+   }
+
+   // 2. Parse & validate input
+   let sessionId: string;
+   let timeSlots: TimeSlot[];
+   try {
+      const rawSlots = formData.get("time_slots")?.toString() ?? "";
+      const parsed = selectAvailabilitiesSchema.safeParse({
+         session_id: formData.get("session_id")?.toString(),
+         time_slots: JSON.parse(rawSlots),
+      });
+
+      if (!parsed.success) {
+         return { errors: parsed.error.flatten().fieldErrors };
+      }
+
+      sessionId = parsed.data.session_id;
+      timeSlots = parsed.data.time_slots as TimeSlot[];
+   } catch {
+      return { errors: { time_slots: ["Invalid time slots format"] } };
+   }
+
+   // 3. Authorization: caller must be the coach or user on this session
+   const result = await getAuthorizedSession(sessionId, callerId);
+   if (!result.ok) {
+      return result.state;
+   }
+
+   // 4. Update the session
+   try {
+      await db
+         .update(coachingSessions)
+         .set({
+            selectedTimeSlots: timeSlots,
+            updatedAt: new Date(),
+         })
+         .where(eq(coachingSessions.id, sessionId));
+   } catch (e) {
+      console.error(e);
+      return {
+         errors: {
+            _form: [
+               e instanceof Error
+                  ? e.message
+                  : "Could not update availabilities",
+            ],
+         },
+      };
+   }
+
+   return { message: "Availabilities updated." };
+}
+
+/**
+ * Select a confirmed time slot for an existing coaching session.
+ *
+ * The chosen `{ start, end }` must be one of the `selected_time_slots`
+ * already stored on the session. On success, `scheduled_at` is set to the
+ * slot's start time and the session status becomes `confirmed`.
+ */
+export async function selectTimeSlot(
+   _prev: SchedulingActionState,
+   formData: FormData,
+): Promise<SchedulingActionState> {
+   // 1. Auth gate
+   const callerId = await getAuthenticatedUserId();
+   if (!callerId) {
+      return { errors: { _form: ["You must be logged in"] } };
+   }
+
+   // 2. Parse & validate input
+   const parsed = selectTimeSlotSchema.safeParse({
+      session_id: formData.get("session_id")?.toString(),
+      start: formData.get("start")?.toString(),
+      end: formData.get("end")?.toString(),
+   });
+
+   if (!parsed.success) {
+      return { errors: parsed.error.flatten().fieldErrors };
+   }
+
+   const { session_id, start, end } = parsed.data;
+
+   // 3. Authorization
+   const result = await getAuthorizedSession(session_id, callerId);
+   if (!result.ok) {
+      return result.state;
+   }
+
+   const { session } = result;
+
+   // 4. Verify the slot exists in the session's available time slots
+   const slots = session.selectedTimeSlots as TimeSlot[] | null;
+   if (!slots || !Array.isArray(slots)) {
+      return {
+         errors: {
+            _form: ["No available time slots have been set for this session"],
+         },
+      };
+   }
+
+   const matchingSlot = slots.find(
+      (s) => s.start === start && s.end === end,
+   );
+   if (!matchingSlot) {
+      return {
+         errors: {
+            _form: [
+               "The selected time slot is not among the available options",
+            ],
+         },
+      };
+   }
+
+   // 5. Confirm the session with the chosen slot
+   try {
+      await db
+         .update(coachingSessions)
+         .set({
+            scheduledAt: new Date(start),
+            status: "confirmed",
+            updatedAt: new Date(),
+         })
+         .where(eq(coachingSessions.id, session_id));
+   } catch (e) {
+      console.error(e);
+      return {
+         errors: {
+            _form: [
+               e instanceof Error
+                  ? e.message
+                  : "Could not confirm the time slot",
+            ],
+         },
+      };
+   }
+
+   return { message: "Time slot confirmed." };
+}


### PR DESCRIPTION
Closes #47

### Overview

selectAvailabilities — Sets available time slots ([{start, end}]) on an existing coaching_sessions row.
selectTimeSlot — Picks one of those slots, setting scheduled_at and confirming the session.

### Testing

Manual testing: Used Drizzle Studio (pnpm db:studio) to create a test coaching session, verified that selected_time_slots, scheduled_at, and status columns update correctly through the full scheduling flow.

Unit testing: Wrote 18 Jest tests covering auth rejection, input validation (Zod), authorization checks, and success paths for both coach and user roles. All passing.


### Checklist
- [x] Code is neat, readable, and works
- [x] Code is commented where appropriate and well-documented
- [x] Commit messages follow our [guidelines](https://www.conventionalcommits.org)
- [x] Issue number is linked
- [x] Branch is linked
- [x] Reviewers are assigned (one of your tech leads)


