### PR TITLE
feat(db): add children and emergency_contacts tables with related fields

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY=sb_publishable_your-key
 DATABASE_URL=postgresql://postgres:password@db.your-project.supabase.co:5432/postgres
 STRIPE_PRICE_ID=

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY=sb_publishable_your-key
+DATABASE_URL=postgresql://postgres:password@db.your-project.supabase.co:5432/postgres
+STRIPE_PRICE_ID=
+STRIPE_SECRET_KEY=
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,0 @@
-NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
-NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY=sb_publishable_your-key
-DATABASE_URL=postgresql://postgres:password@db.your-project.supabase.co:5432/postgres
-STRIPE_PRICE_ID=
-STRIPE_SECRET_KEY=
-NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=

--- a/docs/schema-overview.md
+++ b/docs/schema-overview.md
@@ -62,11 +62,60 @@ erDiagram
         timestamp updated_at
     }
 
+    children {
+        uuid id PK
+        uuid parent_id FK
+        gender gender
+        text first_name
+        text last_name
+        date dob
+        text allergies
+        text medical_conditions
+        text medications
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    emergency_contacts {
+        uuid id PK
+        uuid child_id FK
+        text full_name
+        text email_address
+        text phone_number
+        text relationship
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    extra_questions {
+        uuid id PK
+        uuid service_id FK
+        extra_question_type type
+        text prompt
+        jsonb options
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    extra_question_answers {
+        uuid id PK
+        uuid extra_question_id FK
+        uuid child_id FK
+        text answer "text[]"
+        timestamp created_at
+        timestamp updated_at
+    }
+
     profiles ||--o{ service_bookings : "books"
     services ||--o{ service_bookings : "booked via"
     profiles ||--o{ coaching_sessions : "coaches"
     profiles ||--o{ coaching_sessions : "attends"
     services ||--o{ coaching_sessions : "fulfilled by"
+    profiles ||--o{ children : "parent of"
+    children ||--o{ emergency_contacts : "has"
+    services ||--o{ extra_questions : "defines"
+    extra_questions ||--o{ extra_question_answers : "answered via"
+    children ||--o{ extra_question_answers : "submits"
 ```
 
 ## Enums
@@ -78,3 +127,5 @@ erDiagram
 | `booking_status` | `pending`, `confirmed`, `cancelled` |
 | `webinar_tier` | `free`, `premium` |
 | `session_status` | `pending`, `confirmed`, `cancelled`, `completed` |
+| `gender` | `male`, `female`, `prefer_not_to_say` |
+| `extra_question_type` | `text`, `multiple_choices`, `checkboxes`, `user_agreement` |

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -35,6 +35,13 @@ export const serviceStatusEnum = pgEnum("service_status", [
    "deleted",
    "disabled",
 ]);
+export const genderEnum = pgEnum("gender", ["male", "female", "other"]);
+export const extraQuestionTypeEnum = pgEnum("extra_question_type", [
+   "text",
+   "multiple_choices",
+   "checkboxes",
+   "user_agreement",
+]);
 
 export const profiles = pgTable("profiles", {
    id: uuid("id").primaryKey(),
@@ -133,6 +140,46 @@ export const purchases = pgTable("purchases", {
    productName: text("product_name").notNull(),
    amount: integer("amount").notNull(),
    currency: text("currency").notNull(),
+   createdAt: timestamp("created_at").defaultNow().notNull(),
+   updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+
+export const children = pgTable("children", {
+   id: uuid("id").primaryKey().defaultRandom(),
+   parentId: uuid("parent_id")
+      .references(() => profiles.id, { onDelete: "cascade" })
+      .notNull(),
+   gender: genderEnum("gender").notNull(),
+   firstName: text("first_name").notNull(),
+   lastName: text("last_name").notNull(),
+   dob: date("dob", { mode: "string" }).notNull(),
+   allergies: text("allergies"),
+   medicalConditions: text("medical_conditions"),
+   medications: text("medications"),
+   createdAt: timestamp("created_at").defaultNow().notNull(),
+   updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+
+export const emergencyContacts = pgTable("emergency_contacts", {
+   id: uuid("id").primaryKey().defaultRandom(),
+   childId: uuid("child_id")
+      .references(() => children.id, { onDelete: "cascade" })
+      .notNull(),
+   fullName: text("full_name").notNull(),
+   emailAddress: text("email_address").notNull(),
+   phoneNumber: text("phone_number").notNull(),
+   relationship: text("relationship").notNull(),
+   createdAt: timestamp("created_at").defaultNow().notNull(),
+   updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+
+export const extraQuestions = pgTable("extra_questions", {
+   id: uuid("id").primaryKey().defaultRandom(),
+   serviceId: uuid("service_id")
+      .references(() => services.id, { onDelete: "cascade" })
+      .notNull(),
+   type: extraQuestionTypeEnum("type").notNull(),
+   content: text("content").notNull(),
    createdAt: timestamp("created_at").defaultNow().notNull(),
    updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -12,6 +12,12 @@ import {
 
 export type ProgramSlot = { dayOfWeek: number; time: string };
 
+export type ExtraQuestionOption = {
+   id: string;
+   title: string;
+   description?: string;
+};
+
 export const roleEnum = pgEnum("role", ["user", "admin", "coach"]);
 export const serviceTypeEnum = pgEnum("service_type", [
    "private_lessons",
@@ -179,7 +185,21 @@ export const extraQuestions = pgTable("extra_questions", {
       .references(() => services.id, { onDelete: "cascade" })
       .notNull(),
    type: extraQuestionTypeEnum("type").notNull(),
-   content: text("content").notNull(),
+   prompt: text("prompt").notNull(),
+   options: jsonb("options").$type<ExtraQuestionOption[]>(),
+   createdAt: timestamp("created_at").defaultNow().notNull(),
+   updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+
+export const extraQuestionAnswers = pgTable("extra_question_answers", {
+   id: uuid("id").primaryKey().defaultRandom(),
+   extraQuestionId: uuid("extra_question_id")
+      .references(() => extraQuestions.id, { onDelete: "cascade" })
+      .notNull(),
+   childId: uuid("child_id")
+      .references(() => children.id, { onDelete: "cascade" })
+      .notNull(),
+   answer: text("answer").array().notNull(),
    createdAt: timestamp("created_at").defaultNow().notNull(),
    updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -41,7 +41,7 @@ export const serviceStatusEnum = pgEnum("service_status", [
    "deleted",
    "disabled",
 ]);
-export const genderEnum = pgEnum("gender", ["male", "female", "other"]);
+export const genderEnum = pgEnum("gender", ["male", "female", "prefer_not_to_say"]);
 export const extraQuestionTypeEnum = pgEnum("extra_question_type", [
    "text",
    "multiple_choices",


### PR DESCRIPTION
Closes #60 

### Overview

Updating table

### Testing

Visual inspection, did not want to actually apply the changes to the db to prevent regressions

### Screenshots / Screencasts

n/a

### Checklist
- [x] Code is neat, readable, and works
- [x] Code is commented where appropriate and well-documented
- [x] Commit messages follow our [guidelines](https://www.conventionalcommits.org)
- [x] Issue number is linked
- [x] Branch is linked
- [x] Reviewers are assigned (one of your tech leads)

Tip: You can make the issue and then check them after the fact or replace `[ ]` with `[x]` to check it!

### Notes

There is a bit of an issue with the circular dependency between children and emergency contacts, however I think that the best approach is to ignore it for now and when you try to implement the adding children you will realize the issue and adjust your function accordingly, and at that point we can think about making a generalized function.
