### PR TITLE
Fix/72 remove duration minutes

### DIFF
--- a/app/coaching/actions.ts
+++ b/app/coaching/actions.ts
@@ -44,7 +44,6 @@ export async function submitAvailabilities({
          userId: user.id,
          serviceId: service.id,
          coachId: service.coachId,
-         durationMinutes: service.durationMinutes,
          selectedTimeSlots: availabilities,
          status: "awaiting_payment",
       })

--- a/drizzle/0001_remove_duration_minutes.sql
+++ b/drizzle/0001_remove_duration_minutes.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "coaching_sessions" DROP COLUMN "duration_minutes";--> statement-breakpoint

--- a/drizzle/0001_remove_duration_minutes.sql
+++ b/drizzle/0001_remove_duration_minutes.sql
@@ -1,1 +1,0 @@
-ALTER TABLE "coaching_sessions" DROP COLUMN "duration_minutes";--> statement-breakpoint

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -118,7 +118,6 @@ export const coachingSessions = pgTable("coaching_sessions", {
       .references(() => profiles.id, { onDelete: "cascade" })
       .notNull(),
    scheduledAt: timestamp("scheduled_at"),
-   durationMinutes: integer("duration_minutes").notNull().default(60),
    status: sessionStatusEnum("status").notNull().default("pending"),
    meetingUrl: text("meeting_url"),
    notes: text("notes"),


### PR DESCRIPTION
Closes #72

### Overview

Removed `duration_minutes` column from the `coaching_sessions` table to establish a single source of truth. Session duration now comes directly from the related service record instead of being duplicated in the coaching_sessions table.

**Changes made:**
- Removed `durationMinutes` field from the `coachingSessions` schema definition
- Updated `submitAvailabilities` action to no longer handle duration (implicitly retrieved from service)

### Testing

- Verified `submitAvailabilities` creates coaching sessions without duration_minutes field
- Confirmed schema reflects the column removal

### Screenshots / Screencasts

N/A - Database schema change only

### Checklist
- [x] Code is neat, readable, and works
- [x] Code is commented where appropriate and well-documented
- [x] Commit messages follow our [guidelines](https://www.conventionalcommits.org)
- [x] Issue number is linked
- [x] Branch is linked
- [x] Reviewers are assigned (one of your tech leads)

### Notes

This is a breaking change. Any code accessing `coachingSessions.durationMinutes` will need to fetch the duration from the related `services` record instead.
