### PR TITLE
Feature/74 stripe donations

### DIFF
--- a/app/(authenticated)/checkout/actions.test.ts
+++ b/app/(authenticated)/checkout/actions.test.ts
@@ -5,6 +5,7 @@ import { checkoutDonation } from "./actions";
 
 const createSession = jest.fn();
 const retrieveProduct = jest.fn();
+const retrievePrice = jest.fn();
 const getUser = jest.fn();
 const getOrCreateStripeCustomer = jest.fn();
 const headersGet = jest.fn();
@@ -13,6 +14,7 @@ jest.mock("@/lib/stripe", () => ({
    stripe: {
       checkout: { sessions: { create: (...args: unknown[]) => createSession(...args) } },
       products: { retrieve: (...args: unknown[]) => retrieveProduct(...args) },
+      prices: { retrieve: (...args: unknown[]) => retrievePrice(...args) },
    },
    getOrCreateStripeCustomer: (...args: unknown[]) =>
       getOrCreateStripeCustomer(...args),
@@ -36,6 +38,7 @@ beforeEach(() => {
    getUser.mockResolvedValue(authedUser);
    getOrCreateStripeCustomer.mockResolvedValue("cus_123");
    retrieveProduct.mockResolvedValue({ default_price: "price_donation" });
+   retrievePrice.mockResolvedValue({ custom_unit_amount: { preset: 1000 } });
    createSession.mockResolvedValue({ url: "https://stripe.test/session" });
    headersGet.mockReturnValue("https://app.test");
 });

--- a/app/(authenticated)/checkout/actions.test.ts
+++ b/app/(authenticated)/checkout/actions.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @jest-environment node
+ */
+import { checkoutDonation } from "./actions";
+
+const createSession = jest.fn();
+const retrieveProduct = jest.fn();
+const getUser = jest.fn();
+const getOrCreateStripeCustomer = jest.fn();
+const headersGet = jest.fn();
+
+jest.mock("@/lib/stripe", () => ({
+   stripe: {
+      checkout: { sessions: { create: (...args: unknown[]) => createSession(...args) } },
+      products: { retrieve: (...args: unknown[]) => retrieveProduct(...args) },
+   },
+   getOrCreateStripeCustomer: (...args: unknown[]) =>
+      getOrCreateStripeCustomer(...args),
+}));
+
+jest.mock("@/utils/supabase/server", () => ({
+   createClient: async () => ({ auth: { getUser } }),
+}));
+
+jest.mock("next/headers", () => ({
+   headers: async () => ({ get: (...args: unknown[]) => headersGet(...args) }),
+}));
+
+const authedUser = {
+   data: { user: { id: "user-1", email: "donor@test.com" } },
+};
+
+beforeEach(() => {
+   jest.clearAllMocks();
+   process.env.STRIPE_DONATION_PRODUCT_ID = "prod_test123";
+   getUser.mockResolvedValue(authedUser);
+   getOrCreateStripeCustomer.mockResolvedValue("cus_123");
+   retrieveProduct.mockResolvedValue({ default_price: "price_donation" });
+   createSession.mockResolvedValue({ url: "https://stripe.test/session" });
+   headersGet.mockReturnValue("https://app.test");
+});
+
+describe("checkoutDonation", () => {
+   it("requires an authenticated user", async () => {
+      getUser.mockResolvedValue({ data: { user: null } });
+      const result = await checkoutDonation();
+      expect(result).toEqual({ error: "Not authenticated" });
+      expect(createSession).not.toHaveBeenCalled();
+   });
+
+   it("returns an error when the donation product env var is not set", async () => {
+      delete process.env.STRIPE_DONATION_PRODUCT_ID;
+      const result = await checkoutDonation();
+      expect(result).toEqual({ error: "Donation product not configured" });
+      expect(createSession).not.toHaveBeenCalled();
+   });
+
+   it("creates a checkout session using the donation product's default price", async () => {
+      const result = await checkoutDonation();
+
+      expect(retrieveProduct).toHaveBeenCalledWith("prod_test123");
+      expect(getOrCreateStripeCustomer).toHaveBeenCalledWith(
+         "user-1",
+         "donor@test.com",
+      );
+      expect(createSession).toHaveBeenCalledWith(
+         expect.objectContaining({
+            customer: "cus_123",
+            mode: "payment",
+            metadata: { type: "donation" },
+            line_items: [{ price: "price_donation", quantity: 1 }],
+         }),
+      );
+      expect(result).toEqual({ url: "https://stripe.test/session" });
+   });
+
+   it("derives success/cancel URLs from the request origin", async () => {
+      await checkoutDonation();
+      expect(createSession).toHaveBeenCalledWith(
+         expect.objectContaining({
+            success_url: "https://app.test/checkout/success",
+            cancel_url: "https://app.test/checkout/cancel",
+         }),
+      );
+   });
+
+   it("returns an error when Stripe omits the checkout URL", async () => {
+      createSession.mockResolvedValue({ url: null });
+      const result = await checkoutDonation();
+      expect(result).toEqual({ error: "Stripe did not return a checkout URL" });
+   });
+
+   it("throws when the request origin is missing", async () => {
+      headersGet.mockReturnValue(null);
+      await expect(checkoutDonation()).rejects.toThrow(
+         "Missing request origin",
+      );
+      expect(createSession).not.toHaveBeenCalled();
+   });
+});

--- a/app/(authenticated)/checkout/actions.ts
+++ b/app/(authenticated)/checkout/actions.ts
@@ -123,6 +123,18 @@ export async function checkoutDonation(): Promise<CheckoutResult> {
    const donationProductId = process.env.STRIPE_DONATION_PRODUCT_ID;
    if (!donationProductId) return { error: "Donation product not configured" };
 
+   const product = await stripe.products.retrieve(donationProductId);
+   const priceId = product.default_price;
+
+   if (!priceId || typeof priceId !== "string") {
+      return { error: "Donation product has no default price" };
+   }
+
+   const price = await stripe.prices.retrieve(priceId);
+   if (!price.custom_unit_amount) {
+      return { error: "Donation price is not configured for customer chosen amounts" };
+   }
+
    const result = await createStripeCheckoutSession({
       userId: user.id,
       email: user.email!,

--- a/app/(authenticated)/checkout/actions.ts
+++ b/app/(authenticated)/checkout/actions.ts
@@ -112,6 +112,27 @@ export async function checkoutServiceBooking({
    return { url: result.session.url! };
 }
 
+export async function checkoutDonation(): Promise<CheckoutResult> {
+   const supabase = await createClient();
+   const {
+      data: { user },
+   } = await supabase.auth.getUser();
+   if (!user) return { error: "Not authenticated" };
+
+   const donationProductId = process.env.STRIPE_DONATION_PRODUCT_ID;
+   if (!donationProductId) return { error: "Donation product not configured" };
+
+   const result = await createStripeCheckoutSession({
+      userId: user.id,
+      email: user.email!,
+      stripeProductId: donationProductId,
+      metadata: { type: "donation" },
+   });
+   if ("error" in result) return { error: result.error };
+
+   return { url: result.session.url! };
+}
+
 export async function checkoutCoachingSession({
    coachingSessionId,
 }: {

--- a/app/(authenticated)/checkout/actions.ts
+++ b/app/(authenticated)/checkout/actions.ts
@@ -119,6 +119,7 @@ export async function checkoutDonation(): Promise<CheckoutResult> {
    } = await supabase.auth.getUser();
    if (!user) return { error: "Not authenticated" };
 
+   // This product can have a variable price, adjusted by Stripe Checkout
    const donationProductId = process.env.STRIPE_DONATION_PRODUCT_ID;
    if (!donationProductId) return { error: "Donation product not configured" };
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,9 @@ const createJestConfig = nextJest({
 /** @type {import('jest').Config} */
 const customJestConfig = {
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
+  moduleNameMapper: {
+    "^@/(.*)$": "<rootDir>/$1",
+  },
   testEnvironment: "jest-environment-jsdom",
   modulePathIgnorePatterns: ["<rootDir>/.next/", "<rootDir>/node_modules/"],
   testMatch: ["**/*.test.[jt]s?(x)"],


### PR DESCRIPTION
Closes #74

### Overview

An action that returns a stripe URL for receiving donations. The customers enter their own price.

### Testing

Setup unit testing for basic cases and basic behaviours.

### Screenshots / Screencasts

<img width="994" height="722" alt="image" src="https://github.com/user-attachments/assets/0dfa0514-7a3f-4f8b-bb8e-8a7072a70d1d" />

### Checklist
- [x] Code is neat, readable, and works
- [x] Code is commented where appropriate and well-documented
- [x] Commit messages follow our [guidelines](https://www.conventionalcommits.org)
- [x] Issue number is linked
- [x] Branch is linked
- [x] Reviewers are assigned (one of your tech leads)

Tip: You can make the issue and then check them after the fact or replace `[ ]` with `[x]` to check it!

### Notes

Must add a new `STRIPE_DONATION_PRODUCT_ID` environment variable