### PR TITLE
feat(checkout): implement frontend checkout flow (closes #69)

### DIFF
--- a/app/(authenticated)/checkout/[productId]/availability-calendar.tsx
+++ b/app/(authenticated)/checkout/[productId]/availability-calendar.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import * as React from "react";
+import { addDays, addMinutes, format, startOfDay } from "date-fns";
+
+import { cn } from "@/lib/utils";
+
+const DAY_COUNT = 14;
+const START_HOUR = 8;
+const END_HOUR = 22;
+const SLOT_MINUTES = 30;
+
+export type AvailabilityRange = { start: string; end: string };
+
+export type AvailabilityCalendarProps = {
+   value: AvailabilityRange[];
+   onChange: (next: AvailabilityRange[]) => void;
+};
+
+type CellKey = string; // ISO start datetime
+
+function buildDays(): Date[] {
+   const today = startOfDay(new Date());
+   return Array.from({ length: DAY_COUNT }, (_, i) => addDays(today, i));
+}
+
+function buildSlotsForDay(day: Date): Date[] {
+   const first = addMinutes(day, START_HOUR * 60);
+   const count = ((END_HOUR - START_HOUR) * 60) / SLOT_MINUTES;
+   return Array.from({ length: count }, (_, i) =>
+      addMinutes(first, i * SLOT_MINUTES),
+   );
+}
+
+function rangesToCellSet(ranges: AvailabilityRange[]): Set<CellKey> {
+   const set = new Set<CellKey>();
+   for (const range of ranges) {
+      let cursor = new Date(range.start);
+      const end = new Date(range.end);
+      while (cursor < end) {
+         set.add(cursor.toISOString());
+         cursor = addMinutes(cursor, SLOT_MINUTES);
+      }
+   }
+   return set;
+}
+
+function cellSetToRanges(set: Set<CellKey>): AvailabilityRange[] {
+   const sorted = Array.from(set)
+      .map((iso) => new Date(iso))
+      .sort((a, b) => a.getTime() - b.getTime());
+
+   const ranges: AvailabilityRange[] = [];
+   let rangeStart: Date | null = null;
+   let prev: Date | null = null;
+
+   for (const slot of sorted) {
+      if (!rangeStart || !prev) {
+         rangeStart = slot;
+         prev = slot;
+         continue;
+      }
+      const expected = addMinutes(prev, SLOT_MINUTES);
+      if (slot.getTime() === expected.getTime()) {
+         prev = slot;
+         continue;
+      }
+      ranges.push({
+         start: rangeStart.toISOString(),
+         end: addMinutes(prev, SLOT_MINUTES).toISOString(),
+      });
+      rangeStart = slot;
+      prev = slot;
+   }
+
+   if (rangeStart && prev) {
+      ranges.push({
+         start: rangeStart.toISOString(),
+         end: addMinutes(prev, SLOT_MINUTES).toISOString(),
+      });
+   }
+
+   return ranges;
+}
+
+/**
+ * Mock when2meet-style availability picker. 14 days × 30-minute slots,
+ * click-and-drag to select. Replace with the proper calendar from #12
+ * when it lands — the props shape ({ value, onChange }) is the contract.
+ */
+export function AvailabilityCalendar({
+   value,
+   onChange,
+}: AvailabilityCalendarProps) {
+   const days = React.useMemo(() => buildDays(), []);
+   const timeLabels = React.useMemo(() => buildSlotsForDay(days[0]), [days]);
+
+   const selectedFromProps = React.useMemo(
+      () => rangesToCellSet(value),
+      [value],
+   );
+
+   const [working, setWorking] = React.useState<Set<CellKey> | null>(null);
+   const dragModeRef = React.useRef<"select" | "deselect" | null>(null);
+   const workingRef = React.useRef<Set<CellKey> | null>(null);
+   React.useEffect(() => {
+      workingRef.current = working;
+   }, [working]);
+
+   const displayed = working ?? selectedFromProps;
+
+   const startDrag = (key: CellKey) => {
+      const initiallyOn = selectedFromProps.has(key);
+      dragModeRef.current = initiallyOn ? "deselect" : "select";
+      const next = new Set(selectedFromProps);
+      if (initiallyOn) next.delete(key);
+      else next.add(key);
+      setWorking(next);
+   };
+
+   const continueDrag = (key: CellKey) => {
+      if (!dragModeRef.current) return;
+      setWorking((prev) => {
+         if (!prev) return prev;
+         const next = new Set(prev);
+         if (dragModeRef.current === "select") next.add(key);
+         else next.delete(key);
+         return next;
+      });
+   };
+
+   React.useEffect(() => {
+      function onMouseUp() {
+         if (dragModeRef.current === null) return;
+         dragModeRef.current = null;
+         const finalSet = workingRef.current;
+         setWorking(null);
+         if (finalSet) onChange(cellSetToRanges(finalSet));
+      }
+      window.addEventListener("mouseup", onMouseUp);
+      return () => window.removeEventListener("mouseup", onMouseUp);
+   }, [onChange]);
+
+   return (
+      <div className="w-full select-none overflow-x-auto">
+         <div
+            className="grid gap-1"
+            style={{
+               gridTemplateColumns: `48px repeat(${DAY_COUNT}, minmax(48px, 1fr))`,
+            }}
+         >
+            <div />
+            {days.map((day) => (
+               <div
+                  key={day.toISOString()}
+                  className="text-center text-xs font-medium"
+               >
+                  <div className="text-muted-foreground">
+                     {format(day, "EEE")}
+                  </div>
+                  <div>{format(day, "MMM d")}</div>
+               </div>
+            ))}
+
+            {timeLabels.map((slot) => {
+               const slotKey = format(slot, "HH:mm");
+               return (
+                  <React.Fragment key={slotKey}>
+                     <div className="pr-2 text-right text-[10px] leading-none text-muted-foreground">
+                        {slotKey}
+                     </div>
+                     {days.map((day) => {
+                        const cell = new Date(day);
+                        cell.setHours(slot.getHours(), slot.getMinutes(), 0, 0);
+                        const key = cell.toISOString();
+                        const on = displayed.has(key);
+                        return (
+                           <div
+                              key={key}
+                              role="button"
+                              aria-pressed={on}
+                              tabIndex={0}
+                              onMouseDown={(e) => {
+                                 e.preventDefault();
+                                 startDrag(key);
+                              }}
+                              onMouseEnter={() => continueDrag(key)}
+                              className={cn(
+                                 "h-6 cursor-pointer rounded-sm border border-border/60 transition-colors",
+                                 on
+                                    ? "bg-primary"
+                                    : "bg-muted/30 hover:bg-muted",
+                              )}
+                           />
+                        );
+                     })}
+                  </React.Fragment>
+               );
+            })}
+         </div>
+      </div>
+   );
+}

--- a/app/(authenticated)/checkout/[productId]/checkout-flow.tsx
+++ b/app/(authenticated)/checkout/[productId]/checkout-flow.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import * as React from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+   Card,
+   CardContent,
+   CardDescription,
+   CardFooter,
+   CardHeader,
+   CardTitle,
+} from "@/components/ui/card";
+import type { ServiceView } from "@/app/(authenticated)/services/queries";
+
+import {
+   checkoutServiceBooking,
+   startPrivateLessonCheckout,
+} from "../actions";
+import {
+   AvailabilityCalendar,
+   type AvailabilityRange,
+} from "./availability-calendar";
+import { SubscriptionNeededDialog } from "./subscription-needed-dialog";
+
+type CheckoutFlowProps = {
+   service: ServiceView;
+   hasActiveSubscription: boolean;
+};
+
+function formatPrice(cents: number | null, currency: string | null) {
+   if (cents === null) return "—";
+   const amount = (cents / 100).toFixed(2);
+   const symbol = currency?.toUpperCase() ?? "CAD";
+   return `$${amount} ${symbol}`;
+}
+
+export function CheckoutFlow({
+   service,
+   hasActiveSubscription,
+}: CheckoutFlowProps) {
+   const [step, setStep] = React.useState<"confirm" | "availability">(
+      "confirm",
+   );
+   const [submitting, setSubmitting] = React.useState(false);
+   const [subDialogOpen, setSubDialogOpen] = React.useState(false);
+   const [availabilities, setAvailabilities] = React.useState<
+      AvailabilityRange[]
+   >([]);
+
+   async function handleProgramCheckout() {
+      setSubmitting(true);
+      const result = await checkoutServiceBooking({ serviceId: service.id });
+      if ("error" in result) {
+         setSubmitting(false);
+         toast.error(result.error);
+         return;
+      }
+      window.location.href = result.url;
+   }
+
+   async function handlePrivateLessonCheckout() {
+      if (availabilities.length === 0) {
+         toast.error("Pick at least one availability window.");
+         return;
+      }
+      setSubmitting(true);
+      const result = await startPrivateLessonCheckout({
+         serviceId: service.id,
+         availabilities,
+      });
+      if ("error" in result) {
+         setSubmitting(false);
+         toast.error(result.error);
+         return;
+      }
+      window.location.href = result.url;
+   }
+
+   function handleNextOnConfirm() {
+      if (!hasActiveSubscription) {
+         setSubDialogOpen(true);
+         return;
+      }
+      if (service.type === "private_lessons") {
+         setStep("availability");
+         return;
+      }
+      void handleProgramCheckout();
+   }
+
+   if (step === "availability") {
+      return (
+         <Card>
+            <CardHeader>
+               <CardTitle>Pick your availabilities</CardTitle>
+               <CardDescription>
+                  Select the time windows that work for you over the next two
+                  weeks. Your coach will confirm a slot from your choices.
+               </CardDescription>
+            </CardHeader>
+            <CardContent>
+               <AvailabilityCalendar
+                  value={availabilities}
+                  onChange={setAvailabilities}
+               />
+            </CardContent>
+            <CardFooter className="justify-between">
+               <Button
+                  variant="outline"
+                  onClick={() => setStep("confirm")}
+                  disabled={submitting}
+               >
+                  Back
+               </Button>
+               <Button
+                  onClick={handlePrivateLessonCheckout}
+                  disabled={submitting || availabilities.length === 0}
+               >
+                  {submitting ? "Redirecting…" : "Continue to payment"}
+               </Button>
+            </CardFooter>
+         </Card>
+      );
+   }
+
+   return (
+      <>
+         <Card>
+            <CardHeader>
+               <CardTitle>{service.title ?? "Checkout"}</CardTitle>
+               <CardDescription>
+                  {service.type === "private_lessons"
+                     ? "Private lesson"
+                     : "Program"}
+               </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+               {service.description && (
+                  <p className="text-sm text-muted-foreground">
+                     {service.description}
+                  </p>
+               )}
+               <div className="flex items-center justify-between border-t pt-4">
+                  <span className="text-sm text-muted-foreground">Price</span>
+                  <span className="text-base font-medium">
+                     {formatPrice(service.priceCents, service.priceCurrency)}
+                  </span>
+               </div>
+            </CardContent>
+            <CardFooter className="justify-end">
+               <Button onClick={handleNextOnConfirm} disabled={submitting}>
+                  {submitting ? "Redirecting…" : "Next"}
+               </Button>
+            </CardFooter>
+         </Card>
+         <SubscriptionNeededDialog
+            open={subDialogOpen}
+            onOpenChange={setSubDialogOpen}
+         />
+      </>
+   );
+}

--- a/app/(authenticated)/checkout/[productId]/page.tsx
+++ b/app/(authenticated)/checkout/[productId]/page.tsx
@@ -1,0 +1,59 @@
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { createClient } from "@/utils/supabase/server";
+import { userHasActiveSubscription } from "@/lib/stripe";
+import { getService } from "@/app/(authenticated)/services/queries";
+
+import { CheckoutFlow } from "./checkout-flow";
+
+export default async function CheckoutPage({
+   params,
+}: {
+   params: Promise<{ productId: string }>;
+}) {
+   const { productId } = await params;
+
+   const supabase = await createClient();
+   const {
+      data: { user },
+   } = await supabase.auth.getUser();
+   if (!user) {
+      return <NotAvailable message="You must be signed in to check out." />;
+   }
+
+   const service = await getService(productId);
+   if (!service || service.status !== "active") {
+      return <NotAvailable message="This product isn't available." />;
+   }
+
+   const hasActiveSubscription = await userHasActiveSubscription(user.id);
+
+   return (
+      <main className="mx-auto w-full max-w-xl p-6">
+         <CheckoutFlow
+            service={service}
+            hasActiveSubscription={hasActiveSubscription}
+         />
+      </main>
+   );
+}
+
+function NotAvailable({ message }: { message: string }) {
+   return (
+      <main className="mx-auto flex w-full max-w-xl flex-col gap-4 p-6">
+         <Card>
+            <CardHeader>
+               <CardTitle>Not available</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+               <p className="text-sm text-muted-foreground">{message}</p>
+               <Button asChild variant="outline">
+                  <Link href="/">Go back home</Link>
+               </Button>
+            </CardContent>
+         </Card>
+      </main>
+   );
+}

--- a/app/(authenticated)/checkout/[productId]/subscription-needed-dialog.tsx
+++ b/app/(authenticated)/checkout/[productId]/subscription-needed-dialog.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import * as React from "react";
+import { toast } from "sonner";
+
+import {
+   AlertDialog,
+   AlertDialogAction,
+   AlertDialogCancel,
+   AlertDialogContent,
+   AlertDialogDescription,
+   AlertDialogFooter,
+   AlertDialogHeader,
+   AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+import { startSubscriptionCheckout } from "../actions";
+
+export type SubscriptionNeededDialogProps = {
+   open: boolean;
+   onOpenChange: (open: boolean) => void;
+};
+
+export function SubscriptionNeededDialog({
+   open,
+   onOpenChange,
+}: SubscriptionNeededDialogProps) {
+   const [submitting, setSubmitting] = React.useState(false);
+
+   async function handleConfirm(e: React.MouseEvent) {
+      e.preventDefault();
+      setSubmitting(true);
+      const result = await startSubscriptionCheckout();
+      if ("error" in result) {
+         setSubmitting(false);
+         toast.error(result.error);
+         return;
+      }
+      window.location.href = result.url;
+   }
+
+   return (
+      <AlertDialog open={open} onOpenChange={onOpenChange}>
+         <AlertDialogContent>
+            <AlertDialogHeader>
+               <AlertDialogTitle>Subscription needed</AlertDialogTitle>
+               <AlertDialogDescription>
+                  You need an active subscription before purchasing this
+                  product. Would you like to subscribe now?
+               </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+               <AlertDialogCancel disabled={submitting}>No</AlertDialogCancel>
+               <AlertDialogAction
+                  onClick={handleConfirm}
+                  disabled={submitting}
+               >
+                  {submitting ? "Redirecting…" : "Yes, subscribe"}
+               </AlertDialogAction>
+            </AlertDialogFooter>
+         </AlertDialogContent>
+      </AlertDialog>
+   );
+}

--- a/app/(authenticated)/checkout/actions.ts
+++ b/app/(authenticated)/checkout/actions.ts
@@ -7,6 +7,7 @@ import type Stripe from "stripe";
 import { db } from "@/lib/db";
 import { coachingSessions, serviceBookings, services } from "@/lib/db/schema";
 import { getOrCreateStripeCustomer, stripe } from "@/lib/stripe";
+import { submitAvailabilities, type Availability } from "@/app/coaching/actions";
 import { createClient } from "@/utils/supabase/server";
 
 export type CheckoutResult = { url: string } | { error: string };
@@ -160,5 +161,56 @@ export async function checkoutCoachingSession({
       .where(eq(coachingSessions.id, row.id));
 
    return { url: result.session.url! };
+}
+
+/**
+ * Kick off a Stripe Checkout session for the monthly subscription. Used by
+ * the "subscription needed" modal in the product checkout flow.
+ */
+export async function startSubscriptionCheckout(): Promise<CheckoutResult> {
+   const supabase = await createClient();
+   const {
+      data: { user },
+   } = await supabase.auth.getUser();
+   if (!user) return { error: "Not authenticated" };
+
+   const priceId = process.env.STRIPE_PRICE_ID;
+   if (!priceId) return { error: "Subscription price is not configured" };
+
+   const customerId = await getOrCreateStripeCustomer(user.id, user.email!);
+   const origin = await getRequestOrigin();
+
+   const session = await stripe.checkout.sessions.create({
+      customer: customerId,
+      mode: "subscription",
+      payment_method_types: ["card"],
+      line_items: [{ price: priceId, quantity: 1 }],
+      success_url: `${origin}/checkout/success`,
+      cancel_url: `${origin}/checkout/cancel`,
+   });
+
+   if (!session.url)
+      return { error: "Stripe did not return a checkout URL" };
+   return { url: session.url };
+}
+
+/**
+ * Composite action used by the private-lesson checkout step. Stores the
+ * user's availabilities as a new coaching session, then opens the Stripe
+ * Checkout session for it.
+ */
+export async function startPrivateLessonCheckout({
+   serviceId,
+   availabilities,
+}: {
+   serviceId: string;
+   availabilities: Availability[];
+}): Promise<CheckoutResult> {
+   const created = await submitAvailabilities({ serviceId, availabilities });
+   if ("error" in created) return { error: created.error };
+
+   return checkoutCoachingSession({
+      coachingSessionId: created.coachingSessionId,
+   });
 }
 

--- a/app/(authenticated)/checkout/success/page.tsx
+++ b/app/(authenticated)/checkout/success/page.tsx
@@ -1,38 +1,67 @@
 import { Suspense } from "react";
-import { redirect } from "next/navigation";
-import { createClient } from "@/utils/supabase/server";
-import { syncStripeData } from "@/lib/stripe";
+import Link from "next/link";
+import { eq } from "drizzle-orm";
+
+import { Button } from "@/components/ui/button";
 import { db } from "@/lib/db";
 import { profiles } from "@/lib/db/schema";
-import { eq } from "drizzle-orm";
+import { syncStripeData } from "@/lib/stripe";
+import { createClient } from "@/utils/supabase/server";
 
 export default function CheckoutSuccessPage() {
    return (
-      <Suspense>
-         <SyncAndRedirect />
+      <Suspense fallback={<SuccessShell syncing />}>
+         <SyncAndConfirm />
       </Suspense>
    );
 }
 
-async function SyncAndRedirect(): Promise<never> {
+async function SyncAndConfirm() {
    const supabase = await createClient();
    const {
       data: { user },
    } = await supabase.auth.getUser();
-
-   if (!user) {
-      redirect("/login");
-   }
+   if (!user) return <SuccessShell />;
 
    const profile = await db.query.profiles.findFirst({
       where: eq(profiles.id, user.id),
    });
-
-   if (!profile?.stripeCustomerId) {
-      redirect("/");
+   if (profile?.stripeCustomerId) {
+      await syncStripeData(profile.stripeCustomerId);
    }
 
-   await syncStripeData(profile.stripeCustomerId);
+   return <SuccessShell />;
+}
 
-   redirect("/");
+function SuccessShell({ syncing = false }: { syncing?: boolean }) {
+   return (
+      <div className="flex min-h-screen items-center justify-center px-4">
+         <div className="w-full max-w-md text-center">
+            <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-green-100">
+               <svg
+                  className="h-8 w-8 text-green-600"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+               >
+                  <path
+                     strokeLinecap="round"
+                     strokeLinejoin="round"
+                     d="M5 13l4 4L19 7"
+                  />
+               </svg>
+            </div>
+            <h1 className="mb-2 text-2xl font-bold">Payment successful</h1>
+            <p className="mb-8 text-gray-600">
+               {syncing
+                  ? "Finalizing your purchase…"
+                  : "Thanks — your purchase is confirmed. You'll receive a receipt by email shortly."}
+            </p>
+            <Button asChild>
+               <Link href="/">Back to home</Link>
+            </Button>
+         </div>
+      </div>
+   );
 }

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -107,6 +107,22 @@ export type SubscriptionDetails = {
    paymentMethodLast4: string | null;
 } | null;
 
+/**
+ * Lightweight gate used by the checkout flow. Returns true when the
+ * user has a subscription row with status active or trialing. Avoids
+ * the Stripe round-trip that getSubscriptionDetails does.
+ */
+export async function userHasActiveSubscription(
+   userId: string,
+): Promise<boolean> {
+   const subscription = await db.query.subscriptions.findFirst({
+      where: eq(subscriptions.userId, userId),
+   });
+   return (
+      subscription?.status === "active" || subscription?.status === "trialing"
+   );
+}
+
 export async function getSubscriptionDetails(
    userId: string,
 ): Promise<SubscriptionDetails> {


### PR DESCRIPTION
## Summary

Implements the user-facing checkout flow on top of the backend that landed in #56.

- **`/checkout/[productId]`** — confirmation card with title, description, price, and a `Next` button.
- **Subscription gate** — if the signed-in user has no `active`/`trialing` subscription, clicking `Next` opens a "Subscription needed" AlertDialog. Confirming kicks off a Stripe subscription checkout (separate flow, per spec).
- **Private-lesson step** — for `private_lessons`, `Next` opens a when2meet-style availability picker (next 14 days × 30-min slots, click-and-drag). Submit calls a new `startPrivateLessonCheckout` action that wraps `submitAvailabilities` + `checkoutCoachingSession`.
- **Programs** — `Next` goes straight to `checkoutServiceBooking` → Stripe.
- **Success screen** — `/checkout/success` now shows a real confirmation card with a "Back to home" link (still calls `syncStripeData` so returning from a subscription purchase reflects the new state). `/checkout/cancel` was already the error screen.

### Notes
- The availability picker is a deliberate mock built from shadcn primitives; it'll be swapped out when #12 (the real calendar component) lands. Props are `{ value, onChange }` so the swap is a one-import change.
- Added `userHasActiveSubscription(userId)` in `lib/stripe.ts` — treats both `active` and `trialing` as subscribed, matching the convention from #75 (complimentary trials granted on user creation).
- Entry points to `/checkout/[id]` (WordPress redirects, services list buttons, memberships) are explicitly out of scope.

## Test plan

- [ ] Sign in as a user with no subscription, visit `/checkout/<program-service-id>` → click `Next` → subscription modal appears → "Yes, subscribe" redirects to Stripe checkout.
- [ ] Complete the subscription payment → lands on `/checkout/success` with the success card → home page shows the subscription card as active.
- [ ] As a subscribed user, visit `/checkout/<program-service-id>` → click `Next` → goes straight to Stripe → after payment, a `service_bookings` row exists with status `confirmed` and a `stripeOrderId`.
- [ ] Visit `/checkout/<private-lesson-service-id>` → click `Next` → availability picker step → click-drag a few slots → "Continue to payment" → Stripe → success → a `coaching_sessions` row exists with `status = pending`, `selectedTimeSlots` populated, `stripeOrderId` set.
- [ ] Cancel out of a Stripe session → lands on `/checkout/cancel`.
- [ ] Hit `/checkout/<random-uuid>` → see the "Not available" card, not a crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)