### PR TITLE
Feature/84 admin form tab

### DIFF
--- a/app/(authenticated)/forms/_components/form-actions-cell.tsx
+++ b/app/(authenticated)/forms/_components/form-actions-cell.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import * as React from "react";
+import { Pencil, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+
+import {
+   AlertDialog,
+   AlertDialogAction,
+   AlertDialogCancel,
+   AlertDialogContent,
+   AlertDialogDescription,
+   AlertDialogFooter,
+   AlertDialogHeader,
+   AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import {
+   Tooltip,
+   TooltipContent,
+   TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { deleteForm } from "../actions";
+import type { FormListItem } from "../queries";
+
+export function FormActionsCell({
+   form,
+   onEdit,
+}: {
+   form: FormListItem;
+   onEdit: (form: FormListItem) => void;
+}) {
+   const [deleteOpen, setDeleteOpen] = React.useState(false);
+   const [pending, startTransition] = React.useTransition();
+
+   const handleDelete = () => {
+      const fd = new FormData();
+      fd.set("form_id", form.id);
+      startTransition(async () => {
+         const result = await deleteForm(null, fd);
+         if (result?.errors?._form) {
+            toast.error("Could not delete form", {
+               description: result.errors._form.join(" "),
+            });
+            return;
+         }
+         if (result?.message) {
+            toast.success(result.message);
+            setDeleteOpen(false);
+         }
+      });
+   };
+
+   return (
+      <>
+         <div className="flex items-center justify-end gap-0.5">
+            <Tooltip>
+               <TooltipTrigger asChild>
+                  <Button
+                     variant="ghost"
+                     size="icon-sm"
+                     aria-label="Edit form"
+                     onClick={() => onEdit(form)}
+                  >
+                     <Pencil />
+                  </Button>
+               </TooltipTrigger>
+               <TooltipContent>Edit</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+               <TooltipTrigger asChild>
+                  <Button
+                     variant="ghost"
+                     size="icon-sm"
+                     aria-label="Delete form"
+                     onClick={() => setDeleteOpen(true)}
+                  >
+                     <Trash2 />
+                  </Button>
+               </TooltipTrigger>
+               <TooltipContent>Delete</TooltipContent>
+            </Tooltip>
+         </div>
+
+         <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+            <AlertDialogContent className="sm:max-w-md">
+               <AlertDialogHeader className="place-items-start text-left sm:place-items-start sm:text-left">
+                  <AlertDialogTitle>Delete form?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                     {form.attachedServiceCount > 0
+                        ? `This form is attached to ${form.attachedServiceCount} service(s). Detach it from those services before deleting.`
+                        : `Permanently delete "${form.name}" and all of its questions. This cannot be undone.`}
+                  </AlertDialogDescription>
+               </AlertDialogHeader>
+               <AlertDialogFooter className="sm:flex-row sm:justify-end">
+                  <AlertDialogCancel disabled={pending}>Cancel</AlertDialogCancel>
+                  <AlertDialogAction
+                     disabled={pending || form.attachedServiceCount > 0}
+                     onClick={(e) => {
+                        e.preventDefault();
+                        handleDelete();
+                     }}
+                  >
+                     {pending ? "Deleting..." : "Delete"}
+                  </AlertDialogAction>
+               </AlertDialogFooter>
+            </AlertDialogContent>
+         </AlertDialog>
+      </>
+   );
+}

--- a/app/(authenticated)/forms/_components/form-dialog.tsx
+++ b/app/(authenticated)/forms/_components/form-dialog.tsx
@@ -62,6 +62,8 @@ export function FormDialog(props: Props) {
    const [questions, setQuestions] = React.useState<DraftQuestion[]>([]);
    const [loading, setLoading] = React.useState(false);
    const [editingIndex, setEditingIndex] = React.useState<number | null>(null);
+   const [pendingNewQuestion, setPendingNewQuestion] =
+      React.useState<DraftQuestion | null>(null);
    const [questionDialogOpen, setQuestionDialogOpen] = React.useState(false);
 
    const boundFormAction = React.useCallback(
@@ -129,31 +131,52 @@ export function FormDialog(props: Props) {
    const showForm = !isEdit || (form !== null && !loading);
 
    const openQuestionEditor = (index: number) => {
+      setPendingNewQuestion(null);
       setEditingIndex(index);
       setQuestionDialogOpen(true);
    };
 
+   const handleQuestionDialogOpenChange = (open: boolean) => {
+      setQuestionDialogOpen(open);
+      if (!open) {
+         setPendingNewQuestion(null);
+         setEditingIndex(null);
+      }
+   };
+
    const addQuestion = () => {
-      const next = [...questions, emptyQuestion()];
-      setQuestions(next);
-      openQuestionEditor(next.length - 1);
+      setEditingIndex(questions.length);
+      setPendingNewQuestion(emptyQuestion());
+      setQuestionDialogOpen(true);
    };
 
    const saveQuestion = (updated: DraftQuestion) => {
-      if (editingIndex === null) return;
-      setQuestions((prev) =>
-         prev.map((q, i) => (i === editingIndex ? updated : q)),
-      );
+      if (pendingNewQuestion) {
+         setQuestions((prev) => [...prev, updated]);
+         setPendingNewQuestion(null);
+      } else if (editingIndex !== null) {
+         setQuestions((prev) =>
+            prev.map((q, i) => (i === editingIndex ? updated : q)),
+         );
+      }
+      setEditingIndex(null);
    };
 
    const deleteQuestion = () => {
+      if (pendingNewQuestion) {
+         setPendingNewQuestion(null);
+         setEditingIndex(null);
+         return;
+      }
       if (editingIndex === null) return;
       setQuestions((prev) => prev.filter((_, i) => i !== editingIndex));
       setEditingIndex(null);
    };
 
    const editingQuestion =
-      editingIndex !== null ? (questions[editingIndex] ?? null) : null;
+      pendingNewQuestion ??
+      (editingIndex !== null ? (questions[editingIndex] ?? null) : null);
+   const isEditingNewQuestion = pendingNewQuestion !== null;
 
    return (
       <>
@@ -252,12 +275,12 @@ export function FormDialog(props: Props) {
 
          <QuestionEditDialog
             open={questionDialogOpen}
-            onOpenChange={setQuestionDialogOpen}
+            onOpenChange={handleQuestionDialogOpenChange}
             questionIndex={editingIndex}
             question={editingQuestion}
             onSave={saveQuestion}
             onDelete={deleteQuestion}
-            canDelete={questions.length > 1}
+            canDelete={isEditingNewQuestion || questions.length > 1}
          />
       </>
    );

--- a/app/(authenticated)/forms/_components/form-dialog.tsx
+++ b/app/(authenticated)/forms/_components/form-dialog.tsx
@@ -185,7 +185,7 @@ export function FormDialog(props: Props) {
          <Dialog {...dialogControl}>
             {!isEdit && (
                <DialogTrigger asChild>
-                  <Button>
+                  <Button className="border-primary bg-clip-border hover:border-primary/80 hover:bg-primary/80 active:translate-y-0">
                      <Plus />
                      Add form
                   </Button>

--- a/app/(authenticated)/forms/_components/form-dialog.tsx
+++ b/app/(authenticated)/forms/_components/form-dialog.tsx
@@ -79,8 +79,10 @@ export function FormDialog(props: Props) {
       FormData
    >(boundFormAction, null);
 
+   const editOpen = isEdit ? props.open : false;
+
    React.useEffect(() => {
-      if (!isEdit || !form?.id || !props.open) return;
+      if (!isEdit || !form?.id || !editOpen) return;
 
       let cancelled = false;
       setLoading(true);
@@ -104,7 +106,7 @@ export function FormDialog(props: Props) {
       return () => {
          cancelled = true;
       };
-   }, [isEdit, form?.id, isEdit ? props.open : false]);
+   }, [isEdit, form?.id, editOpen]);
 
    const closeRef = React.useRef<HTMLButtonElement>(null);
    const prevState = React.useRef<FormActionState>(null);

--- a/app/(authenticated)/forms/_components/form-dialog.tsx
+++ b/app/(authenticated)/forms/_components/form-dialog.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import * as React from "react";
+import { useActionState } from "react";
+import { Plus } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+   Dialog,
+   DialogClose,
+   DialogContent,
+   DialogDescription,
+   DialogFooter,
+   DialogHeader,
+   DialogTitle,
+   DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Spinner } from "@/components/ui/spinner";
+
+import {
+   createForm,
+   loadFormForEdit,
+   updateForm,
+   type FormActionState,
+} from "../actions";
+import type { FormListItem } from "../queries";
+import { FormQuestionsList } from "./form-questions-list";
+import {
+   emptyQuestion,
+   type DraftQuestion,
+   questionsForSubmit,
+} from "./form-question-shared";
+import { QuestionEditDialog } from "./question-edit-dialog";
+
+type Props =
+   | { mode: "add" }
+   | {
+        mode: "edit";
+        form: FormListItem | null;
+        open: boolean;
+        onOpenChange: (open: boolean) => void;
+     };
+
+function FieldError({ messages }: { messages?: string[] }) {
+   if (!messages?.length) return null;
+   return (
+      <ul className="flex flex-col gap-0.5 text-xs text-destructive">
+         {messages.map((m, i) => (
+            <li key={i}>{m}</li>
+         ))}
+      </ul>
+   );
+}
+
+export function FormDialog(props: Props) {
+   const isEdit = props.mode === "edit";
+   const form = isEdit ? props.form : null;
+
+   const [name, setName] = React.useState("");
+   const [questions, setQuestions] = React.useState<DraftQuestion[]>([]);
+   const [loading, setLoading] = React.useState(false);
+   const [editingIndex, setEditingIndex] = React.useState<number | null>(null);
+   const [questionDialogOpen, setQuestionDialogOpen] = React.useState(false);
+
+   const boundFormAction = React.useCallback(
+      (prev: FormActionState, formData: FormData) => {
+         formData.set("questions", JSON.stringify(questionsForSubmit(questions)));
+         return isEdit ? updateForm(prev, formData) : createForm(prev, formData);
+      },
+      [isEdit, questions],
+   );
+
+   const [state, formAction, pending] = useActionState<
+      FormActionState,
+      FormData
+   >(boundFormAction, null);
+
+   React.useEffect(() => {
+      if (!isEdit || !form?.id || !props.open) return;
+
+      let cancelled = false;
+      setLoading(true);
+      loadFormForEdit(form.id)
+         .then((data) => {
+            if (cancelled || !data) return;
+            setName(data.name);
+            setQuestions(
+               data.questions.map((q) => ({
+                  clientId: crypto.randomUUID(),
+                  type: q.type,
+                  prompt: q.prompt,
+                  options: q.options ?? undefined,
+               })),
+            );
+         })
+         .finally(() => {
+            if (!cancelled) setLoading(false);
+         });
+
+      return () => {
+         cancelled = true;
+      };
+   }, [isEdit, form?.id, isEdit ? props.open : false]);
+
+   const closeRef = React.useRef<HTMLButtonElement>(null);
+   const prevState = React.useRef<FormActionState>(null);
+   React.useEffect(() => {
+      if (state === prevState.current) return;
+      prevState.current = state;
+      if (state?.message && !state.errors) {
+         if (isEdit && props.mode === "edit") {
+            props.onOpenChange(false);
+         } else {
+            closeRef.current?.click();
+            setName("");
+            setQuestions([]);
+         }
+      }
+   }, [state, isEdit, props]);
+
+   const errors = state?.errors;
+
+   const dialogControl = isEdit
+      ? { open: props.open, onOpenChange: props.onOpenChange }
+      : {};
+
+   const showForm = !isEdit || (form !== null && !loading);
+
+   const openQuestionEditor = (index: number) => {
+      setEditingIndex(index);
+      setQuestionDialogOpen(true);
+   };
+
+   const addQuestion = () => {
+      const next = [...questions, emptyQuestion()];
+      setQuestions(next);
+      openQuestionEditor(next.length - 1);
+   };
+
+   const saveQuestion = (updated: DraftQuestion) => {
+      if (editingIndex === null) return;
+      setQuestions((prev) =>
+         prev.map((q, i) => (i === editingIndex ? updated : q)),
+      );
+   };
+
+   const deleteQuestion = () => {
+      if (editingIndex === null) return;
+      setQuestions((prev) => prev.filter((_, i) => i !== editingIndex));
+      setEditingIndex(null);
+   };
+
+   const editingQuestion =
+      editingIndex !== null ? (questions[editingIndex] ?? null) : null;
+
+   return (
+      <>
+         <Dialog {...dialogControl}>
+            {!isEdit && (
+               <DialogTrigger asChild>
+                  <Button>
+                     <Plus />
+                     Add form
+                  </Button>
+               </DialogTrigger>
+            )}
+            <DialogContent className="flex max-h-[90vh] w-full max-w-[calc(100%-2rem)] flex-col gap-0 overflow-hidden p-0 sm:max-w-2xl">
+               <DialogHeader className="shrink-0 border-b border-border px-4 py-4">
+                  <DialogTitle>{isEdit ? "Edit form" : "New form"}</DialogTitle>
+                  <DialogDescription>
+                     {isEdit
+                        ? form && form.attachedServiceCount > 0
+                           ? `Used by ${form.attachedServiceCount} service(s). Changes apply everywhere this form is attached.`
+                           : "Update the form name and questions."
+                        : "Create a reusable form for kid services."}
+                  </DialogDescription>
+               </DialogHeader>
+
+               {loading && isEdit ? (
+                  <div className="flex flex-1 items-center justify-center px-4 py-12">
+                     <Spinner className="size-8 text-muted-foreground" />
+                  </div>
+               ) : showForm ? (
+                  <form
+                     key={form?.id ?? "new"}
+                     action={formAction}
+                     className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
+                  >
+                     {form && (
+                        <input type="hidden" name="form_id" value={form.id} />
+                     )}
+
+                     <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-4 py-4">
+                        <div className="flex flex-col gap-1.5">
+                           <Label htmlFor="name">Name</Label>
+                           <Input
+                              id="name"
+                              name="name"
+                              required
+                              value={name}
+                              onChange={(e) => setName(e.target.value)}
+                           />
+                           <FieldError messages={errors?.name} />
+                        </div>
+
+                        <div className="flex min-w-0 flex-col gap-2">
+                           <div className="flex items-center justify-between gap-2">
+                              <Label>Questions</Label>
+                              <Button
+                                 type="button"
+                                 variant="outline"
+                                 size="sm"
+                                 onClick={addQuestion}
+                              >
+                                 <Plus className="size-4" />
+                                 Add question
+                              </Button>
+                           </div>
+                           <FormQuestionsList
+                              questions={questions}
+                              onChange={setQuestions}
+                              onEdit={openQuestionEditor}
+                           />
+                           <FieldError messages={errors?.questions} />
+                        </div>
+
+                        <FieldError messages={errors?._form} />
+                     </div>
+
+                     <DialogFooter className="mx-0 mb-0 mt-0 shrink-0 flex-row justify-end gap-2 border-t border-border bg-muted/30 px-4 py-4">
+                        <DialogClose ref={closeRef} asChild>
+                           <Button type="button" variant="outline">
+                              Cancel
+                           </Button>
+                        </DialogClose>
+                        <Button type="submit" disabled={pending}>
+                           {pending
+                              ? isEdit
+                                 ? "Saving..."
+                                 : "Creating..."
+                              : isEdit
+                                ? "Save changes"
+                                : "Create form"}
+                        </Button>
+                     </DialogFooter>
+                  </form>
+               ) : null}
+            </DialogContent>
+         </Dialog>
+
+         <QuestionEditDialog
+            open={questionDialogOpen}
+            onOpenChange={setQuestionDialogOpen}
+            questionIndex={editingIndex}
+            question={editingQuestion}
+            onSave={saveQuestion}
+            onDelete={deleteQuestion}
+            canDelete={questions.length > 1}
+         />
+      </>
+   );
+}

--- a/app/(authenticated)/forms/_components/form-question-shared.ts
+++ b/app/(authenticated)/forms/_components/form-question-shared.ts
@@ -1,0 +1,67 @@
+import type { ExtraQuestionType } from "../queries";
+
+export type DraftOption = {
+   id: string;
+   title: string;
+   description?: string;
+};
+
+export type DraftQuestion = {
+   clientId: string;
+   type: ExtraQuestionType;
+   prompt: string;
+   options?: DraftOption[];
+};
+
+export const QUESTION_TYPE_LABELS: Record<ExtraQuestionType, string> = {
+   text: "Text",
+   multiple_choices: "Multiple choice",
+   checkboxes: "Checkboxes",
+   user_agreement: "User agreement",
+};
+
+export function emptyQuestion(): DraftQuestion {
+   return {
+      clientId: crypto.randomUUID(),
+      type: "text",
+      prompt: "",
+   };
+}
+
+export function needsOptions(type: ExtraQuestionType): boolean {
+   return type === "multiple_choices" || type === "checkboxes";
+}
+
+export function questionSummary(question: DraftQuestion): string {
+   const trimmed = question.prompt.trim();
+   if (trimmed) return trimmed;
+   return "No prompt yet";
+}
+
+export function questionsForSubmit(questions: DraftQuestion[]) {
+   return questions.map(({ type, prompt, options }) => ({
+      type,
+      prompt,
+      options,
+   }));
+}
+
+export function reorderQuestions(
+   questions: DraftQuestion[],
+   fromIndex: number,
+   toIndex: number,
+): DraftQuestion[] {
+   if (
+      fromIndex === toIndex ||
+      fromIndex < 0 ||
+      toIndex < 0 ||
+      fromIndex >= questions.length ||
+      toIndex >= questions.length
+   ) {
+      return questions;
+   }
+   const next = [...questions];
+   const [moved] = next.splice(fromIndex, 1);
+   next.splice(toIndex, 0, moved);
+   return next;
+}

--- a/app/(authenticated)/forms/_components/form-questions-list.tsx
+++ b/app/(authenticated)/forms/_components/form-questions-list.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import * as React from "react";
+import { GripVertical, Pencil, Trash2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+import {
+   type DraftQuestion,
+   QUESTION_TYPE_LABELS,
+   questionSummary,
+   reorderQuestions,
+} from "./form-question-shared";
+
+type FormQuestionsListProps = {
+   questions: DraftQuestion[];
+   onChange: (questions: DraftQuestion[]) => void;
+   onEdit: (index: number) => void;
+};
+
+export function FormQuestionsList({
+   questions,
+   onChange,
+   onEdit,
+}: FormQuestionsListProps) {
+   const [dragIndex, setDragIndex] = React.useState<number | null>(null);
+   const [overIndex, setOverIndex] = React.useState<number | null>(null);
+
+   const handleDrop = (toIndex: number) => {
+      if (dragIndex === null) return;
+      onChange(reorderQuestions(questions, dragIndex, toIndex));
+      setDragIndex(null);
+      setOverIndex(null);
+   };
+
+   if (questions.length === 0) {
+      return (
+         <p className="rounded-md border border-dashed border-border px-3 py-6 text-center text-sm text-muted-foreground">
+            No questions yet. Add one to get started.
+         </p>
+      );
+   }
+
+   return (
+      <ul className="flex flex-col gap-2">
+         {questions.map((question, index) => (
+            <li
+               key={question.clientId}
+               onDragOver={(e) => {
+                  e.preventDefault();
+                  setOverIndex(index);
+               }}
+               onDragLeave={() => {
+                  setOverIndex((prev) => (prev === index ? null : prev));
+               }}
+               onDrop={(e) => {
+                  e.preventDefault();
+                  handleDrop(index);
+               }}
+               className={cn(
+                  "flex min-w-0 items-stretch overflow-hidden rounded-md border border-border bg-background transition-colors",
+                  overIndex === index &&
+                     dragIndex !== null &&
+                     dragIndex !== index &&
+                     "border-primary/50 bg-primary/5",
+               )}
+            >
+               <button
+                  type="button"
+                  draggable
+                  aria-label={`Reorder question ${index + 1}`}
+                  onDragStart={(e) => {
+                     setDragIndex(index);
+                     e.dataTransfer.effectAllowed = "move";
+                     e.dataTransfer.setData("text/plain", String(index));
+                  }}
+                  onDragEnd={() => {
+                     setDragIndex(null);
+                     setOverIndex(null);
+                  }}
+                  className="flex shrink-0 cursor-grab items-center border-r border-border px-2 text-muted-foreground hover:bg-muted/50 active:cursor-grabbing"
+               >
+                  <GripVertical className="size-4" />
+               </button>
+
+               <button
+                  type="button"
+                  onClick={() => onEdit(index)}
+                  className="flex min-w-0 flex-1 flex-col gap-0.5 px-3 py-2.5 text-left hover:bg-muted/30"
+               >
+                  <span className="text-xs font-medium text-muted-foreground">
+                     Question {index + 1} · {QUESTION_TYPE_LABELS[question.type]}
+                  </span>
+                  <span className="truncate text-sm">
+                     {questionSummary(question)}
+                  </span>
+               </button>
+
+               <div className="flex shrink-0 items-center gap-0.5 pr-1">
+                  <Button
+                     type="button"
+                     variant="ghost"
+                     size="icon-sm"
+                     aria-label={`Edit question ${index + 1}`}
+                     onClick={() => onEdit(index)}
+                  >
+                     <Pencil className="size-4" />
+                  </Button>
+                  <Button
+                     type="button"
+                     variant="ghost"
+                     size="icon-sm"
+                     aria-label={`Remove question ${index + 1}`}
+                     disabled={questions.length === 1}
+                     onClick={() =>
+                        onChange(questions.filter((_, i) => i !== index))
+                     }
+                  >
+                     <Trash2 className="size-4" />
+                  </Button>
+               </div>
+            </li>
+         ))}
+      </ul>
+   );
+}

--- a/app/(authenticated)/forms/_components/form-questions-list.tsx
+++ b/app/(authenticated)/forms/_components/form-questions-list.tsx
@@ -1,6 +1,22 @@
 "use client";
 
 import * as React from "react";
+import {
+   closestCenter,
+   DndContext,
+   KeyboardSensor,
+   PointerSensor,
+   useSensor,
+   useSensors,
+   type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+   SortableContext,
+   sortableKeyboardCoordinates,
+   useSortable,
+   verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { GripVertical, Pencil, Trash2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -10,7 +26,6 @@ import {
    type DraftQuestion,
    QUESTION_TYPE_LABELS,
    questionSummary,
-   reorderQuestions,
 } from "./form-question-shared";
 
 type FormQuestionsListProps = {
@@ -19,19 +34,151 @@ type FormQuestionsListProps = {
    onEdit: (index: number) => void;
 };
 
+const embeddedButtonClassName =
+   "rounded-none border-0 shadow-none focus-visible:border-0 focus-visible:ring-0 active:translate-y-0";
+
+type SortableQuestionItemProps = {
+   question: DraftQuestion;
+   index: number;
+   canRemove: boolean;
+   onEdit: (index: number) => void;
+   onRemove: (index: number) => void;
+};
+
+function SortableQuestionItem({
+   question,
+   index,
+   canRemove,
+   onEdit,
+   onRemove,
+}: SortableQuestionItemProps) {
+   const {
+      attributes,
+      listeners,
+      setNodeRef,
+      setActivatorNodeRef,
+      transform,
+      transition,
+      isDragging,
+      isOver,
+   } = useSortable({ id: question.clientId });
+
+   return (
+      <li
+         ref={setNodeRef}
+         style={{
+            transform: CSS.Transform.toString(transform),
+            transition,
+         }}
+         className={cn(
+            "flex min-w-0 items-stretch overflow-hidden rounded-md border border-border bg-background transition-colors",
+            isDragging && "z-10 opacity-50",
+            isOver && !isDragging && "border-primary/50 bg-primary/5",
+         )}
+      >
+         <Button
+            asChild
+            variant="ghost"
+            className={cn(
+               embeddedButtonClassName,
+               "flex h-auto min-h-0 shrink-0 cursor-grab self-stretch px-2 text-muted-foreground hover:bg-muted/50 active:cursor-grabbing",
+            )}
+         >
+            <button
+               ref={setActivatorNodeRef}
+               type="button"
+               aria-label={`Reorder question ${index + 1}`}
+               {...attributes}
+               {...listeners}
+            >
+               <GripVertical className="size-4" />
+            </button>
+         </Button>
+
+         <div
+            role="presentation"
+            className="w-px shrink-0 self-stretch bg-border"
+         />
+
+         <Button
+            type="button"
+            variant="ghost"
+            onClick={() => onEdit(index)}
+            className={cn(
+               embeddedButtonClassName,
+               "flex h-auto min-h-0 min-w-0 flex-1 flex-col items-start justify-start gap-0.5 px-3 py-2.5 text-left font-normal whitespace-normal hover:bg-muted/30",
+            )}
+         >
+            <span className="text-xs font-medium text-muted-foreground">
+               Question {index + 1} · {QUESTION_TYPE_LABELS[question.type]}
+            </span>
+            <span className="truncate text-sm">
+               {questionSummary(question)}
+            </span>
+         </Button>
+
+         <div className="flex shrink-0 items-center gap-0.5 pr-1">
+            <Button
+               type="button"
+               variant="ghost"
+               size="icon-sm"
+               aria-label={`Edit question ${index + 1}`}
+               onClick={() => onEdit(index)}
+               className={embeddedButtonClassName}
+            >
+               <Pencil className="size-4" />
+            </Button>
+            <Button
+               type="button"
+               variant="ghost"
+               size="icon-sm"
+               aria-label={`Remove question ${index + 1}`}
+               disabled={!canRemove}
+               onClick={() => onRemove(index)}
+               className={embeddedButtonClassName}
+            >
+               <Trash2 className="size-4" />
+            </Button>
+         </div>
+      </li>
+   );
+}
+
 export function FormQuestionsList({
    questions,
    onChange,
    onEdit,
 }: FormQuestionsListProps) {
-   const [dragIndex, setDragIndex] = React.useState<number | null>(null);
-   const [overIndex, setOverIndex] = React.useState<number | null>(null);
+   const itemIds = React.useMemo(
+      () => questions.map((question) => question.clientId),
+      [questions],
+   );
 
-   const handleDrop = (toIndex: number) => {
-      if (dragIndex === null) return;
-      onChange(reorderQuestions(questions, dragIndex, toIndex));
-      setDragIndex(null);
-      setOverIndex(null);
+   const sensors = useSensors(
+      useSensor(PointerSensor, {
+         activationConstraint: { distance: 8 },
+      }),
+      useSensor(KeyboardSensor, {
+         coordinateGetter: sortableKeyboardCoordinates,
+      }),
+   );
+
+   const handleDragEnd = (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+
+      const fromIndex = questions.findIndex(
+         (question) => question.clientId === active.id,
+      );
+      const toIndex = questions.findIndex(
+         (question) => question.clientId === over.id,
+      );
+      if (fromIndex === -1 || toIndex === -1) return;
+
+      const next = [...questions];
+      const [moved] = next.splice(fromIndex, 1);
+      next.splice(toIndex, 0, moved);
+      onChange(next);
    };
 
    if (questions.length === 0) {
@@ -43,85 +190,29 @@ export function FormQuestionsList({
    }
 
    return (
-      <ul className="flex flex-col gap-2">
-         {questions.map((question, index) => (
-            <li
-               key={question.clientId}
-               onDragOver={(e) => {
-                  e.preventDefault();
-                  setOverIndex(index);
-               }}
-               onDragLeave={() => {
-                  setOverIndex((prev) => (prev === index ? null : prev));
-               }}
-               onDrop={(e) => {
-                  e.preventDefault();
-                  handleDrop(index);
-               }}
-               className={cn(
-                  "flex min-w-0 items-stretch overflow-hidden rounded-md border border-border bg-background transition-colors",
-                  overIndex === index &&
-                     dragIndex !== null &&
-                     dragIndex !== index &&
-                     "border-primary/50 bg-primary/5",
-               )}
-            >
-               <button
-                  type="button"
-                  draggable
-                  aria-label={`Reorder question ${index + 1}`}
-                  onDragStart={(e) => {
-                     setDragIndex(index);
-                     e.dataTransfer.effectAllowed = "move";
-                     e.dataTransfer.setData("text/plain", String(index));
-                  }}
-                  onDragEnd={() => {
-                     setDragIndex(null);
-                     setOverIndex(null);
-                  }}
-                  className="flex shrink-0 cursor-grab items-center border-r border-border px-2 text-muted-foreground hover:bg-muted/50 active:cursor-grabbing"
-               >
-                  <GripVertical className="size-4" />
-               </button>
-
-               <button
-                  type="button"
-                  onClick={() => onEdit(index)}
-                  className="flex min-w-0 flex-1 flex-col gap-0.5 px-3 py-2.5 text-left hover:bg-muted/30"
-               >
-                  <span className="text-xs font-medium text-muted-foreground">
-                     Question {index + 1} · {QUESTION_TYPE_LABELS[question.type]}
-                  </span>
-                  <span className="truncate text-sm">
-                     {questionSummary(question)}
-                  </span>
-               </button>
-
-               <div className="flex shrink-0 items-center gap-0.5 pr-1">
-                  <Button
-                     type="button"
-                     variant="ghost"
-                     size="icon-sm"
-                     aria-label={`Edit question ${index + 1}`}
-                     onClick={() => onEdit(index)}
-                  >
-                     <Pencil className="size-4" />
-                  </Button>
-                  <Button
-                     type="button"
-                     variant="ghost"
-                     size="icon-sm"
-                     aria-label={`Remove question ${index + 1}`}
-                     disabled={questions.length === 1}
-                     onClick={() =>
-                        onChange(questions.filter((_, i) => i !== index))
+      <DndContext
+         sensors={sensors}
+         collisionDetection={closestCenter}
+         onDragEnd={handleDragEnd}
+      >
+         <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
+            <ul className="flex flex-col gap-2">
+               {questions.map((question, index) => (
+                  <SortableQuestionItem
+                     key={question.clientId}
+                     question={question}
+                     index={index}
+                     canRemove={questions.length > 1}
+                     onEdit={onEdit}
+                     onRemove={(removeIndex) =>
+                        onChange(
+                           questions.filter((_, i) => i !== removeIndex),
+                        )
                      }
-                  >
-                     <Trash2 className="size-4" />
-                  </Button>
-               </div>
-            </li>
-         ))}
-      </ul>
+                  />
+               ))}
+            </ul>
+         </SortableContext>
+      </DndContext>
    );
 }

--- a/app/(authenticated)/forms/_components/forms-data-table.tsx
+++ b/app/(authenticated)/forms/_components/forms-data-table.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import * as React from "react";
+import { ColumnDef } from "@tanstack/react-table";
+
+import { DataTable } from "@/components/data-table";
+import type { FormListItem } from "../queries";
+import { FormActionsCell } from "./form-actions-cell";
+
+export function FormsDataTable({
+   forms,
+   onEdit,
+}: {
+   forms: FormListItem[];
+   onEdit: (form: FormListItem) => void;
+}) {
+   const columns = React.useMemo<ColumnDef<FormListItem>[]>(
+      () => [
+         {
+            accessorKey: "name",
+            header: "Name",
+            cell: ({ row }) => (
+               <span className="font-medium">{row.original.name}</span>
+            ),
+         },
+         {
+            accessorKey: "questionCount",
+            header: "Questions",
+         },
+         {
+            accessorKey: "attachedServiceCount",
+            header: "Used by",
+            cell: ({ row }) => {
+               const n = row.original.attachedServiceCount;
+               return `${n} service${n === 1 ? "" : "s"}`;
+            },
+         },
+         {
+            id: "actions",
+            header: () => <div className="text-right">Actions</div>,
+            cell: ({ row }) => (
+               <FormActionsCell form={row.original} onEdit={onEdit} />
+            ),
+         },
+      ],
+      [onEdit],
+   );
+
+   return (
+      <DataTable
+         columns={columns}
+         data={forms}
+         emptyMessage="No forms yet. Create one to get started."
+         rowLabel={(n) => `${n} form${n === 1 ? "" : "s"}`}
+      />
+   );
+}

--- a/app/(authenticated)/forms/_components/forms-data-table.tsx
+++ b/app/(authenticated)/forms/_components/forms-data-table.tsx
@@ -3,9 +3,9 @@
 import * as React from "react";
 import { ColumnDef } from "@tanstack/react-table";
 
-import { DataTable } from "@/components/data-table";
+import { UsersDataTable } from "@/app/(authenticated)/users/_components/users-data-table";
+import { FormActionsCell } from "@/app/(authenticated)/forms/_components/form-actions-cell";
 import type { FormListItem } from "../queries";
-import { FormActionsCell } from "./form-actions-cell";
 
 export function FormsDataTable({
    forms,
@@ -19,17 +19,22 @@ export function FormsDataTable({
          {
             accessorKey: "name",
             header: "Name",
+            meta: { colWidth: "40%" },
             cell: ({ row }) => (
-               <span className="font-medium">{row.original.name}</span>
+               <span className="block min-w-0 truncate font-medium">
+                  {row.original.name}
+               </span>
             ),
          },
          {
             accessorKey: "questionCount",
             header: "Questions",
+            meta: { colWidth: "18%" },
          },
          {
             accessorKey: "attachedServiceCount",
             header: "Used by",
+            meta: { colWidth: "20%" },
             cell: ({ row }) => {
                const n = row.original.attachedServiceCount;
                return `${n} service${n === 1 ? "" : "s"}`;
@@ -38,6 +43,11 @@ export function FormsDataTable({
          {
             id: "actions",
             header: () => <div className="text-right">Actions</div>,
+            meta: {
+               colWidth: "22%",
+               thClassName: "text-right",
+               tdClassName: "text-right",
+            },
             cell: ({ row }) => (
                <FormActionsCell form={row.original} onEdit={onEdit} />
             ),
@@ -47,7 +57,7 @@ export function FormsDataTable({
    );
 
    return (
-      <DataTable
+      <UsersDataTable
          columns={columns}
          data={forms}
          emptyMessage="No forms yet. Create one to get started."

--- a/app/(authenticated)/forms/_components/forms-table.tsx
+++ b/app/(authenticated)/forms/_components/forms-table.tsx
@@ -9,11 +9,13 @@ export function FormsTable({ forms }: { forms: FormListItem[] }) {
    const [editing, setEditing] = React.useState<FormListItem | null>(null);
 
    return (
-      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-         <div className="flex w-full min-w-0 shrink-0 justify-end pb-2">
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+         <div className="flex w-full min-w-0 shrink-0 justify-end p-0.5 pb-2">
             <FormDialog mode="add" />
          </div>
-         <FormsDataTable forms={forms} onEdit={setEditing} />
+         <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+            <FormsDataTable forms={forms} onEdit={setEditing} />
+         </div>
          <FormDialog
             mode="edit"
             form={editing}

--- a/app/(authenticated)/forms/_components/forms-table.tsx
+++ b/app/(authenticated)/forms/_components/forms-table.tsx
@@ -6,22 +6,22 @@ import { FormsDataTable } from "./forms-data-table";
 import { FormDialog } from "./form-dialog";
 
 export function FormsTable({ forms }: { forms: FormListItem[] }) {
-  const [editing, setEditing] = React.useState<FormListItem | null>(null);
+   const [editing, setEditing] = React.useState<FormListItem | null>(null);
 
-  return (
-    <>
-      <div className="flex justify-end">
-        <FormDialog mode="add" />
+   return (
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+         <div className="flex w-full min-w-0 shrink-0 justify-end pb-2">
+            <FormDialog mode="add" />
+         </div>
+         <FormsDataTable forms={forms} onEdit={setEditing} />
+         <FormDialog
+            mode="edit"
+            form={editing}
+            open={editing !== null}
+            onOpenChange={(open) => {
+               if (!open) setEditing(null);
+            }}
+         />
       </div>
-      <FormsDataTable forms={forms} onEdit={setEditing} />
-      <FormDialog
-        mode="edit"
-        form={editing}
-        open={editing !== null}
-        onOpenChange={(open) => {
-          if (!open) setEditing(null);
-        }}
-      />
-    </>
-  );
+   );
 }

--- a/app/(authenticated)/forms/_components/forms-table.tsx
+++ b/app/(authenticated)/forms/_components/forms-table.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import * as React from "react";
+import type { FormListItem } from "../queries";
+import { FormsDataTable } from "./forms-data-table";
+import { FormDialog } from "./form-dialog";
+
+export function FormsTable({ forms }: { forms: FormListItem[] }) {
+  const [editing, setEditing] = React.useState<FormListItem | null>(null);
+
+  return (
+    <>
+      <div className="flex justify-end">
+        <FormDialog mode="add" />
+      </div>
+      <FormsDataTable forms={forms} onEdit={setEditing} />
+      <FormDialog
+        mode="edit"
+        form={editing}
+        open={editing !== null}
+        onOpenChange={(open) => {
+          if (!open) setEditing(null);
+        }}
+      />
+    </>
+  );
+}

--- a/app/(authenticated)/forms/_components/question-edit-dialog.tsx
+++ b/app/(authenticated)/forms/_components/question-edit-dialog.tsx
@@ -1,0 +1,319 @@
+"use client";
+
+import * as React from "react";
+import { Plus, X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+   Dialog,
+   DialogContent,
+   DialogDescription,
+   DialogFooter,
+   DialogHeader,
+   DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+   Select,
+   SelectContent,
+   SelectItem,
+   SelectTrigger,
+   SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+
+import {
+   type DraftOption,
+   type DraftQuestion,
+   needsOptions,
+   QUESTION_TYPE_LABELS,
+} from "./form-question-shared";
+import type { ExtraQuestionType } from "../queries";
+
+function FieldError({ messages }: { messages?: string[] }) {
+   if (!messages?.length) return null;
+   return (
+      <ul className="flex flex-col gap-0.5 text-xs text-destructive">
+         {messages.map((m, i) => (
+            <li key={i}>{m}</li>
+         ))}
+      </ul>
+   );
+}
+
+type QuestionEditDialogProps = {
+   open: boolean;
+   onOpenChange: (open: boolean) => void;
+   questionIndex: number | null;
+   question: DraftQuestion | null;
+   onSave: (question: DraftQuestion) => void;
+   onDelete?: () => void;
+   canDelete?: boolean;
+};
+
+function OptionEditor({
+   option,
+   optionIndex,
+   canRemove,
+   onChange,
+   onRemove,
+}: {
+   option: DraftOption;
+   optionIndex: number;
+   canRemove: boolean;
+   onChange: (patch: Partial<DraftOption>) => void;
+   onRemove: () => void;
+}) {
+   return (
+      <div className="rounded-lg border border-border bg-muted/20 p-3">
+         <div className="mb-2 flex items-center justify-between gap-2">
+            <span className="text-xs font-medium text-muted-foreground">
+               Option {optionIndex + 1}
+            </span>
+            <Button
+               type="button"
+               variant="ghost"
+               size="icon-sm"
+               aria-label={`Remove option ${optionIndex + 1}`}
+               disabled={!canRemove}
+               onClick={onRemove}
+            >
+               <X className="size-4" />
+            </Button>
+         </div>
+         <div className="flex flex-col gap-2">
+            <Input
+               placeholder="Option title"
+               value={option.title}
+               onChange={(e) => onChange({ title: e.target.value })}
+            />
+            <Input
+               placeholder="Description (optional)"
+               value={option.description ?? ""}
+               onChange={(e) =>
+                  onChange({
+                     description: e.target.value || undefined,
+                  })
+               }
+            />
+         </div>
+      </div>
+   );
+}
+
+export function QuestionEditDialog({
+   open,
+   onOpenChange,
+   questionIndex,
+   question,
+   onSave,
+   onDelete,
+   canDelete = false,
+}: QuestionEditDialogProps) {
+   const [draft, setDraft] = React.useState<DraftQuestion | null>(null);
+   const [errors, setErrors] = React.useState<Record<string, string[]>>({});
+
+   React.useEffect(() => {
+      if (open && question) {
+         setDraft({
+            ...question,
+            options: question.options?.map((o) => ({ ...o })),
+         });
+         setErrors({});
+      }
+   }, [open, question]);
+
+   if (!draft) return null;
+
+   const showOptions = needsOptions(draft.type);
+
+   const updateOption = (optionIndex: number, patch: Partial<DraftOption>) => {
+      setDraft((prev) => {
+         if (!prev) return prev;
+         return {
+            ...prev,
+            options: (prev.options ?? []).map((o, i) =>
+               i === optionIndex ? { ...o, ...patch } : o,
+            ),
+         };
+      });
+   };
+
+   const addOption = () => {
+      setDraft((prev) => {
+         if (!prev) return prev;
+         return {
+            ...prev,
+            options: [
+               ...(prev.options ?? []),
+               { id: crypto.randomUUID(), title: "" },
+            ],
+         };
+      });
+   };
+
+   const removeOption = (optionIndex: number) => {
+      setDraft((prev) => {
+         if (!prev) return prev;
+         return {
+            ...prev,
+            options: (prev.options ?? []).filter((_, i) => i !== optionIndex),
+         };
+      });
+   };
+
+   const validate = (): boolean => {
+      const nextErrors: Record<string, string[]> = {};
+      if (!draft.prompt.trim()) {
+         nextErrors.prompt = ["Prompt is required"];
+      }
+      if (needsOptions(draft.type)) {
+         const options = draft.options ?? [];
+         if (options.length === 0) {
+            nextErrors.options = ["At least one option is required"];
+         } else if (options.some((o) => !o.title.trim())) {
+            nextErrors.options = ["Each option needs a title"];
+         }
+      }
+      setErrors(nextErrors);
+      return Object.keys(nextErrors).length === 0;
+   };
+
+   const handleSave = () => {
+      if (!validate()) return;
+      onSave(draft);
+      onOpenChange(false);
+   };
+
+   const title =
+      questionIndex !== null
+         ? `Question ${questionIndex + 1}`
+         : "New question";
+
+   return (
+      <Dialog open={open} onOpenChange={onOpenChange}>
+         <DialogContent className="flex max-h-[90vh] w-full max-w-[calc(100%-2rem)] flex-col gap-0 overflow-hidden p-0 sm:max-w-xl">
+            <DialogHeader className="shrink-0 border-b border-border px-4 py-4">
+               <DialogTitle>{title}</DialogTitle>
+               <DialogDescription>
+                  Configure the question type, prompt, and options.
+               </DialogDescription>
+            </DialogHeader>
+
+            <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-4 py-4">
+               <div className="flex flex-col gap-1.5">
+                  <Label>Type</Label>
+                  <Select
+                     value={draft.type}
+                     onValueChange={(v) => {
+                        const type = v as ExtraQuestionType;
+                        setDraft((prev) => {
+                           if (!prev) return prev;
+                           return {
+                              ...prev,
+                              type,
+                              options: needsOptions(type)
+                                 ? prev.options?.length
+                                    ? prev.options
+                                    : [{ id: crypto.randomUUID(), title: "" }]
+                                 : undefined,
+                           };
+                        });
+                     }}
+                  >
+                     <SelectTrigger className="w-full">
+                        <SelectValue />
+                     </SelectTrigger>
+                     <SelectContent>
+                        {(
+                           Object.keys(QUESTION_TYPE_LABELS) as ExtraQuestionType[]
+                        ).map((t) => (
+                           <SelectItem key={t} value={t}>
+                              {QUESTION_TYPE_LABELS[t]}
+                           </SelectItem>
+                        ))}
+                     </SelectContent>
+                  </Select>
+               </div>
+
+               <div className="flex flex-col gap-1.5">
+                  <Label>Prompt</Label>
+                  <Textarea
+                     value={draft.prompt}
+                     onChange={(e) =>
+                        setDraft((prev) =>
+                           prev ? { ...prev, prompt: e.target.value } : prev,
+                        )
+                     }
+                     rows={3}
+                     className="max-h-40 resize-y"
+                  />
+                  <FieldError messages={errors.prompt} />
+               </div>
+
+               {showOptions && (
+                  <div className="flex flex-col gap-3">
+                     <div className="flex items-center justify-between gap-2">
+                        <Label className="mb-0">Options</Label>
+                        <Button
+                           type="button"
+                           variant="outline"
+                           size="sm"
+                           onClick={addOption}
+                        >
+                           <Plus className="size-4" />
+                           Add option
+                        </Button>
+                     </div>
+                     <div className="flex flex-col gap-2">
+                        {(draft.options ?? []).map((option, optionIndex) => (
+                           <OptionEditor
+                              key={option.id}
+                              option={option}
+                              optionIndex={optionIndex}
+                              canRemove={(draft.options?.length ?? 0) > 1}
+                              onChange={(patch) =>
+                                 updateOption(optionIndex, patch)
+                              }
+                              onRemove={() => removeOption(optionIndex)}
+                           />
+                        ))}
+                     </div>
+                     <FieldError messages={errors.options} />
+                  </div>
+               )}
+            </div>
+
+            <DialogFooter className="mx-0 mb-0 mt-0 shrink-0 flex-row items-center justify-between gap-3 border-t border-border bg-muted/30 px-4 py-4">
+               {canDelete && onDelete ? (
+                  <Button
+                     type="button"
+                     variant="destructive"
+                     onClick={() => {
+                        onDelete();
+                        onOpenChange(false);
+                     }}
+                  >
+                     Delete question
+                  </Button>
+               ) : (
+                  <span />
+               )}
+               <div className="flex shrink-0 gap-2">
+                  <Button
+                     type="button"
+                     variant="outline"
+                     onClick={() => onOpenChange(false)}
+                  >
+                     Cancel
+                  </Button>
+                  <Button type="button" onClick={handleSave}>
+                     Save question
+                  </Button>
+               </div>
+            </DialogFooter>
+         </DialogContent>
+      </Dialog>
+   );
+}

--- a/app/(authenticated)/forms/actions.ts
+++ b/app/(authenticated)/forms/actions.ts
@@ -1,0 +1,228 @@
+"use server";
+
+import { revalidatePath, updateTag } from "next/cache";
+import { count, eq } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "@/lib/db";
+import { extraQuestions, forms, services } from "@/lib/db/schema";
+import { requireAdmin } from "@/lib/auth/require-admin";
+import {
+   createFormSchema,
+   updateFormSchema,
+   deleteFormSchema,
+} from "./schema";
+import { getForm, type FormView } from "./queries";
+
+export type FormActionState = {
+   errors?: Record<string, string[]>;
+   message?: string;
+} | null;
+
+const FORMS_PATH = "/forms";
+const FORMS_TAG = "forms";
+
+type QuestionInput = z.infer<typeof createFormSchema>["questions"];
+
+function bustFormsCache() {
+   updateTag(FORMS_TAG);
+   revalidatePath(FORMS_PATH);
+}
+
+function field(formData: FormData, name: string): string | undefined {
+   const v = formData.get(name);
+   return v === null ? undefined : v.toString();
+}
+
+function parseQuestionsFromFormData(formData: FormData) {
+   const raw = field(formData, "questions");
+   if (!raw) {
+      return {
+         ok: false as const,
+         errors: { questions: ["At least one question is required"] },
+      };
+   }
+
+   try {
+      const parsed = JSON.parse(raw);
+      return { ok: true as const, value: parsed };
+   } catch {
+      return {
+         ok: false as const,
+         errors: { questions: ["Invalid questions format"] },
+      };
+   }
+}
+
+function parseCreatePayload(formData: FormData) {
+   const questionsResult = parseQuestionsFromFormData(formData);
+   if (!questionsResult.ok) return questionsResult;
+
+   const parsed = createFormSchema.safeParse({
+      name: field(formData, "name"),
+      questions: questionsResult.value,
+   });
+
+   if (!parsed.success) {
+      return { ok: false as const, errors: parsed.error.flatten().fieldErrors };
+   }
+   return { ok: true as const, value: parsed.data };
+}
+
+function parseUpdatePayload(formData: FormData) {
+   const questionsResult = parseQuestionsFromFormData(formData);
+   if (!questionsResult.ok) return questionsResult;
+
+   const parsed = updateFormSchema.safeParse({
+      form_id: field(formData, "form_id"),
+      name: field(formData, "name"),
+      questions: questionsResult.value,
+   });
+
+   if (!parsed.success) {
+      return { ok: false as const, errors: parsed.error.flatten().fieldErrors };
+   }
+   return { ok: true as const, value: parsed.data };
+}
+
+async function insertQuestions(formId: string, questions: QuestionInput) {
+   if (questions.length === 0) return;
+
+   await db.insert(extraQuestions).values(
+      questions.map((q, index) => ({
+         formId,
+         sortOrder: index,
+         type: q.type,
+         prompt: q.prompt,
+         options: q.options ?? null,
+      })),
+   );
+}
+
+export async function loadFormForEdit(formId: string): Promise<FormView | null> {
+   try {
+      await requireAdmin();
+   } catch {
+      return null;
+   }
+   return getForm(formId);
+}
+
+export async function createForm(
+   _prev: FormActionState,
+   formData: FormData,
+): Promise<FormActionState> {
+   try {
+      await requireAdmin();
+   } catch {
+      return { errors: { _form: ["Unauthorized"] } };
+   }
+
+   const parsed = parseCreatePayload(formData);
+   if (!parsed.ok) return { errors: parsed.errors };
+
+   const { name, questions } = parsed.value;
+
+   const [form] = await db
+      .insert(forms)
+      .values({
+         name,
+      })
+      .returning({ id: forms.id });
+
+   if (!form) {
+      return { errors: { _form: ["Failed to create form. Please try again."] } };
+   }
+
+   await insertQuestions(form.id, questions);
+
+   bustFormsCache();
+   return { message: "Form created." };
+}
+
+export async function updateForm(
+   _prev: FormActionState,
+   formData: FormData,
+): Promise<FormActionState> {
+   try {
+      await requireAdmin();
+   } catch {
+      return { errors: { _form: ["Unauthorized"] } };
+   }
+
+   const parsed = parseUpdatePayload(formData);
+   if (!parsed.ok) return { errors: parsed.errors };
+
+   const { form_id, name, questions } = parsed.value;
+
+   const existing = await db
+      .select({ id: forms.id })
+      .from(forms)
+      .where(eq(forms.id, form_id))
+      .limit(1);
+
+   if (!existing.length) {
+      return { errors: { _form: ["Form not found"] } };
+   }
+
+   await db
+      .update(forms)
+      .set({
+         name,
+         updatedAt: new Date(),
+      })
+      .where(eq(forms.id, form_id));
+
+   await db.delete(extraQuestions).where(eq(extraQuestions.formId, form_id));
+   await insertQuestions(form_id, questions);
+
+   bustFormsCache();
+   return { message: "Form updated." };
+}
+
+export async function deleteForm(
+   _prev: FormActionState,
+   formData: FormData,
+): Promise<FormActionState> {
+   try {
+      await requireAdmin();
+   } catch {
+      return { errors: { _form: ["Unauthorized"] } };
+   }
+
+   const parsed = deleteFormSchema.safeParse({
+      form_id: field(formData, "form_id"),
+   });
+   if (!parsed.success) {
+      return { errors: parsed.error.flatten().fieldErrors };
+   }
+
+   const { form_id } = parsed.data;
+
+   const [serviceRow] = await db
+      .select({ count: count() })
+      .from(services)
+      .where(eq(services.formId, form_id));
+
+   const attachedCount = serviceRow?.count ?? 0;
+   if (attachedCount > 0) {
+      return {
+         errors: {
+            _form: [
+               `This form is attached to ${attachedCount} service(s). Detach it before deleting.`,
+            ],
+         },
+      };
+   }
+
+   const deleted = await db
+      .delete(forms)
+      .where(eq(forms.id, form_id))
+      .returning({ id: forms.id });
+
+   if (!deleted.length) {
+      return { errors: { _form: ["Form not found"] } };
+   }
+
+   bustFormsCache();
+   return { message: "Form deleted." };
+}

--- a/app/(authenticated)/forms/actions.ts
+++ b/app/(authenticated)/forms/actions.ts
@@ -84,10 +84,16 @@ function parseUpdatePayload(formData: FormData) {
    return { ok: true as const, value: parsed.data };
 }
 
-async function insertQuestions(formId: string, questions: QuestionInput) {
+type FormDb = Pick<typeof db, "insert">;
+
+async function insertQuestions(
+   formId: string,
+   questions: QuestionInput,
+   client: FormDb = db,
+) {
    if (questions.length === 0) return;
 
-   await db.insert(extraQuestions).values(
+   await client.insert(extraQuestions).values(
       questions.map((q, index) => ({
          formId,
          sortOrder: index,
@@ -122,18 +128,22 @@ export async function createForm(
 
    const { name, questions } = parsed.value;
 
-   const [form] = await db
-      .insert(forms)
-      .values({
-         name,
-      })
-      .returning({ id: forms.id });
+   try {
+      await db.transaction(async (tx) => {
+         const [form] = await tx
+            .insert(forms)
+            .values({ name })
+            .returning({ id: forms.id });
 
-   if (!form) {
+         if (!form) {
+            throw new Error("Failed to create form");
+         }
+
+         await insertQuestions(form.id, questions, tx);
+      });
+   } catch {
       return { errors: { _form: ["Failed to create form. Please try again."] } };
    }
-
-   await insertQuestions(form.id, questions);
 
    bustFormsCache();
    return { message: "Form created." };
@@ -164,16 +174,24 @@ export async function updateForm(
       return { errors: { _form: ["Form not found"] } };
    }
 
-   await db
-      .update(forms)
-      .set({
-         name,
-         updatedAt: new Date(),
-      })
-      .where(eq(forms.id, form_id));
+   try {
+      await db.transaction(async (tx) => {
+         await tx
+            .update(forms)
+            .set({
+               name,
+               updatedAt: new Date(),
+            })
+            .where(eq(forms.id, form_id));
 
-   await db.delete(extraQuestions).where(eq(extraQuestions.formId, form_id));
-   await insertQuestions(form_id, questions);
+         await tx
+            .delete(extraQuestions)
+            .where(eq(extraQuestions.formId, form_id));
+         await insertQuestions(form_id, questions, tx);
+      });
+   } catch {
+      return { errors: { _form: ["Failed to update form. Please try again."] } };
+   }
 
    bustFormsCache();
    return { message: "Form updated." };

--- a/app/(authenticated)/forms/layout.tsx
+++ b/app/(authenticated)/forms/layout.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+
+/** Bounded height for /forms so the table can paginate inside the column. */
+export default function FormsLayout({
+   children,
+}: {
+   children: ReactNode;
+}) {
+   return (
+      <div className="flex h-full max-h-full min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden">
+         {children}
+      </div>
+   );
+}

--- a/app/(authenticated)/forms/page.tsx
+++ b/app/(authenticated)/forms/page.tsx
@@ -23,9 +23,11 @@ async function FormsContent() {
    const forms = await listForms();
 
    return (
-      <main className="flex min-h-screen flex-col gap-6 p-8">
-         <h1 className="text-3xl font-bold">Forms</h1>
-         <FormsTable forms={forms} />
+      <main className="flex h-full max-h-full min-h-0 w-full min-w-0 flex-1 flex-col gap-4 overflow-hidden p-8">
+         <h1 className="shrink-0 text-3xl font-bold">Forms</h1>
+         <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+            <FormsTable forms={forms} />
+         </div>
       </main>
    );
 }

--- a/app/(authenticated)/forms/page.tsx
+++ b/app/(authenticated)/forms/page.tsx
@@ -1,0 +1,31 @@
+import { Suspense } from "react";
+import { redirect } from "next/navigation";
+import { Spinner } from "@/components/ui/spinner";
+import { requireAdmin } from "@/lib/auth/require-admin";
+import { listForms } from "./queries";
+import { FormsTable } from "./_components/forms-table";
+
+export default function FormsPage() {
+   return (
+      <Suspense fallback={<Spinner className="size-8 text-muted-foreground" />}>
+         <FormsContent />
+      </Suspense>
+   );
+}
+
+async function FormsContent() {
+   try {
+      await requireAdmin();
+   } catch {
+      redirect("/");
+   }
+
+   const forms = await listForms();
+
+   return (
+      <main className="flex min-h-screen flex-col gap-6 p-8">
+         <h1 className="text-3xl font-bold">Forms</h1>
+         <FormsTable forms={forms} />
+      </main>
+   );
+}

--- a/app/(authenticated)/forms/queries.ts
+++ b/app/(authenticated)/forms/queries.ts
@@ -1,0 +1,108 @@
+import { ExtraQuestionOption, extraQuestions, forms, services} from "@/lib/db/schema";
+import { cacheTag } from "next/cache";
+import { db } from "@/lib/db";
+import { asc,desc, eq ,count} from "drizzle-orm";
+
+export type ExtraQuestionType = "text" | "multiple_choices" | "checkboxes" | "user_agreement";
+
+export type QuestionView = {
+    id: string;
+    sortOrder: number;
+    type: ExtraQuestionType;
+    prompt: string;
+    options: ExtraQuestionOption[] | null;
+}
+
+export type FormListItem = {
+    id: string;
+    name: string;
+    questionCount: number;
+    attachedServiceCount: number;
+    createdAt: Date;
+    updatedAt: Date;
+}
+
+export type FormView = FormListItem & {
+    questions: QuestionView[];
+  };
+
+const FORMS_TAG = "forms";
+export async function listForms(): Promise<FormListItem[]> {
+    "use cache";
+    cacheTag(FORMS_TAG);
+
+    const rows =  await db
+        .select()
+        .from(forms)
+        .orderBy(desc(forms.createdAt));
+
+    return Promise.all(
+        rows.map(async (row) => {
+            const [questionRow] = await db
+                .select({ count: count() })
+                .from(extraQuestions)
+                .where(eq(extraQuestions.formId, row.id));
+
+            const [serviceRow] = await db
+                .select({ count: count() })
+                .from(services)
+                .where(eq(services.formId, row.id));
+            
+            return {
+                id: row.id,
+                name: row.name,
+                questionCount: questionRow?.count ?? 0,
+                attachedServiceCount: serviceRow?.count ?? 0,
+                createdAt: row.createdAt,
+                updatedAt: row.updatedAt,
+            }
+        })
+    )
+}
+
+
+export async function getForm(id: string): Promise<FormView | null> {
+    "use cache";
+    cacheTag(FORMS_TAG);
+  
+    const [form] = await db
+      .select()
+      .from(forms)
+      .where(eq(forms.id, id))
+      .limit(1);
+  
+    if (!form) return null;
+  
+    const questionRows = await db
+      .select({
+        id: extraQuestions.id,
+        sortOrder: extraQuestions.sortOrder,
+        type: extraQuestions.type,
+        prompt: extraQuestions.prompt,
+        options: extraQuestions.options,
+      })
+      .from(extraQuestions)
+      .where(eq(extraQuestions.formId, id))
+      .orderBy(asc(extraQuestions.sortOrder));
+  
+    const [serviceRow] = await db
+      .select({ count: count() })
+      .from(services)
+      .where(eq(services.formId, id));
+  
+    return {
+      id: form.id,
+      name: form.name,
+      questionCount: questionRows.length,
+      attachedServiceCount: serviceRow?.count ?? 0,
+      createdAt: form.createdAt,
+      updatedAt: form.updatedAt,
+      questions: questionRows.map((q) => ({
+        id: q.id,
+        sortOrder: q.sortOrder,
+        type: q.type,
+        prompt: q.prompt,
+        options: q.options ?? null,
+      })),
+    };
+  }

--- a/app/(authenticated)/forms/queries.ts
+++ b/app/(authenticated)/forms/queries.ts
@@ -1,7 +1,12 @@
-import { ExtraQuestionOption, extraQuestions, forms, services} from "@/lib/db/schema";
+import {
+   ExtraQuestionOption,
+   extraQuestions,
+   forms,
+   services,
+} from "@/lib/db/schema";
 import { cacheTag } from "next/cache";
 import { db } from "@/lib/db";
-import { asc,desc, eq ,count} from "drizzle-orm";
+import { asc, count, desc, eq, sql } from "drizzle-orm";
 
 export type ExtraQuestionType = "text" | "multiple_choices" | "checkboxes" | "user_agreement";
 
@@ -28,36 +33,32 @@ export type FormView = FormListItem & {
 
 const FORMS_TAG = "forms";
 export async function listForms(): Promise<FormListItem[]> {
-    "use cache";
-    cacheTag(FORMS_TAG);
+   "use cache";
+   cacheTag(FORMS_TAG);
 
-    const rows =  await db
-        .select()
-        .from(forms)
-        .orderBy(desc(forms.createdAt));
+   const rows = await db
+      .select({
+         id: forms.id,
+         name: forms.name,
+         createdAt: forms.createdAt,
+         updatedAt: forms.updatedAt,
+         questionCount: sql<number>`cast(count(distinct ${extraQuestions.id}) as integer)`,
+         attachedServiceCount: sql<number>`cast(count(distinct ${services.id}) as integer)`,
+      })
+      .from(forms)
+      .leftJoin(extraQuestions, eq(extraQuestions.formId, forms.id))
+      .leftJoin(services, eq(services.formId, forms.id))
+      .groupBy(forms.id, forms.name, forms.createdAt, forms.updatedAt)
+      .orderBy(desc(forms.createdAt));
 
-    return Promise.all(
-        rows.map(async (row) => {
-            const [questionRow] = await db
-                .select({ count: count() })
-                .from(extraQuestions)
-                .where(eq(extraQuestions.formId, row.id));
-
-            const [serviceRow] = await db
-                .select({ count: count() })
-                .from(services)
-                .where(eq(services.formId, row.id));
-            
-            return {
-                id: row.id,
-                name: row.name,
-                questionCount: questionRow?.count ?? 0,
-                attachedServiceCount: serviceRow?.count ?? 0,
-                createdAt: row.createdAt,
-                updatedAt: row.updatedAt,
-            }
-        })
-    )
+   return rows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      questionCount: Number(row.questionCount),
+      attachedServiceCount: Number(row.attachedServiceCount),
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+   }));
 }
 
 

--- a/app/(authenticated)/forms/schema.ts
+++ b/app/(authenticated)/forms/schema.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+
+const extraQuestionTypeSchema = z.enum([
+  "text",
+  "multiple_choices",
+  "checkboxes",
+  "user_agreement",
+]);
+
+const optionSchema = z.object({
+  id: z.string().min(1),
+  title: z.string().min(1),
+  description: z.string().optional(),
+});
+
+const questionSchema = z
+  .object({
+    type: extraQuestionTypeSchema,
+    prompt: z.string().min(1, "Prompt is required"),
+    options: z.array(optionSchema).optional(),
+  })
+  .superRefine((q, ctx) => {
+    const needsOptions =
+      q.type === "multiple_choices" || q.type === "checkboxes";
+    if (needsOptions && (!q.options || q.options.length === 0)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "At least one option is required",
+        path: ["options"],
+      });
+    }
+  });
+
+export const createFormSchema = z.object({
+  name: z.string().min(1, "Name is required"),
+  questions: z.array(questionSchema).min(1, "At least one question is required"),
+});
+
+export const updateFormSchema = createFormSchema.extend({
+  form_id: z.string().uuid(),
+});
+
+export const deleteFormSchema = z.object({
+  form_id: z.string().uuid(),
+});

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -9,6 +9,7 @@ import {
    CreditCard,
    MonitorSmartphone,
    Settings,
+   Form,
 } from "lucide-react";
 import {
    Sidebar,
@@ -31,6 +32,7 @@ const navItems = [
    { title: "USERS", href: "/users", icon: Users },
    { title: "FINANCE", href: "/finance", icon: CreditCard },
    { title: "MEMBERSHIPS", href: "/memberships", icon: MonitorSmartphone },
+   { title: "FORMS" , href: "/forms", icon: Form}
 ];
 
 export function AppSidebar({

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -74,6 +74,8 @@ export const services = pgTable("services", {
    coachId: uuid("coach_id").references(() => profiles.id, {
       onDelete: "set null",
    }),
+   formId: uuid("form_id")
+      .references(() => forms.id, { onDelete: "set null" }),
    createdAt: timestamp("created_at").defaultNow().notNull(),
    updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });
@@ -188,9 +190,10 @@ export const emergencyContacts = pgTable("emergency_contacts", {
 
 export const extraQuestions = pgTable("extra_questions", {
    id: uuid("id").primaryKey().defaultRandom(),
-   serviceId: uuid("service_id")
-      .references(() => services.id, { onDelete: "cascade" })
+   formId: uuid("form_id")
+      .references(() => forms.id, { onDelete: "cascade" })
       .notNull(),
+   sortOrder: integer("sort_order").notNull(),
    type: extraQuestionTypeEnum("type").notNull(),
    prompt: text("prompt").notNull(),
    options: jsonb("options").$type<ExtraQuestionOption[]>(),
@@ -210,3 +213,10 @@ export const extraQuestionAnswers = pgTable("extra_question_answers", {
    createdAt: timestamp("created_at").defaultNow().notNull(),
    updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });
+
+export const forms = pgTable("forms", {
+   id: uuid("id").primaryKey().defaultRandom(),
+   name: text("name").notNull(),
+   createdAt: timestamp("created_at").defaultNow().notNull(),
+   updatedAt: timestamp("updated_at").defaultNow().notNull(),
+})

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "test:ci": "jest --ci --coverage"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@stripe/stripe-js": "^9.0.0",
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.99.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.4)
       '@stripe/stripe-js':
         specifier: ^9.0.0
         version: 9.2.0
@@ -356,6 +365,28 @@ packages:
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@dotenvx/dotenvx@1.59.1':
     resolution: {integrity: sha512-Qg+meC+XFxliuVSDlEPkKnaUjdaJKK6FNx/Wwl2UxhQR8pyPIuLhMavsF7ePdB9qFZUWV1jEK3ckbJir/WmF4w==}
@@ -5582,6 +5613,31 @@ snapshots:
   '@bcoe/v8-coverage@0.2.3': {}
 
   '@date-fns/tz@1.4.1': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
 
   '@dotenvx/dotenvx@1.59.1':
     dependencies:


### PR DESCRIPTION
Closes #84

### Overview

Adds an admin Forms tab so admins can create and manage reusable form templates (name + ordered questions) for kid services.

Done in this PR:

- DB schema: forms table, extra_questions linked by form_id, services.form_id FK
Admin CRUD at /forms (list, create, edit, delete)
- Question types: text, multiple choice, checkboxes, user agreement
- Drag-and-drop question reordering; nested dialog for editing questions
- Delete blocked when a form is attached to a service
- Create/update wrapped in DB transactions
- Sidebar nav link; table layout matches Users/Services pattern

### Testing

manual testing 

### Screenshots / Screencasts
<img width="2308" height="947" alt="image" src="https://github.com/user-attachments/assets/61368e4e-e098-4c76-bf43-d7de88ac4b22" />
<img width="700" height="475" alt="image" src="https://github.com/user-attachments/assets/305caa36-1af8-4ce8-b86f-92f4f10e96df" />
<img width="598" height="389" alt="image" src="https://github.com/user-attachments/assets/ed5978d5-03b2-4ffb-8beb-8bd3ea4eb3f7" />

{Screenshots or screen recording of your changes if this issue involves any frontend components or affects any frontend functionality.}

### Checklist
- [x] Code is neat, readable, and works
- [x] Code is commented where appropriate and well-documented
- [x] Commit messages follow our [guidelines](https://www.conventionalcommits.org)
- [x] Issue number is linked
- [x] Branch is linked
- [x] Reviewers are assigned (one of your tech leads)

Tip: You can make the issue and then check them after the fact or replace `[ ]` with `[x]` to check it!

### Notes

{Any issues/suggestions relating to the ticket, repo, assignments, TL duties; please mention here!}
