### PR TITLE
feat: implement Stripe transaction history and refund functionality f…

### DIFF
--- a/app/(authenticated)/users/_components/components/user-transactions-modals.tsx
+++ b/app/(authenticated)/users/_components/components/user-transactions-modals.tsx
@@ -2,7 +2,6 @@
 
 import * as React from "react";
 import {
-   Loader2,
    ArrowLeft,
    ArrowRight,
 } from "lucide-react";
@@ -76,6 +75,7 @@ export function UserTransactionsModal({
       isFullRefund: boolean;
       amountCents: number;
       displayAmount: string;
+      idempotencyKey: string;
    } | null>(null);
 
    const fetchTransactions = React.useCallback(
@@ -157,32 +157,34 @@ export function UserTransactionsModal({
          displayAmount = formatAmount(refundAmountCents, currency);
       }
 
+      const idempotencyKey = typeof crypto.randomUUID === "function" 
+         ? crypto.randomUUID() 
+         : Math.random().toString(36).substring(2) + Date.now().toString(36);
+
       setConfirmRefund({
          chargeId,
          isFullRefund,
          amountCents: refundAmountCents,
          displayAmount,
+         idempotencyKey,
       });
    };
 
    // Step 2: Executes the refund Server Action after confirmation
    const executeRefund = async () => {
       if (!confirmRefund) return;
-      const { chargeId, isFullRefund, amountCents } = confirmRefund;
+      const { chargeId, isFullRefund, amountCents, idempotencyKey } = confirmRefund;
       setConfirmRefund(null); // Close confirmation immediately
-
-      const idempotency = typeof crypto.randomUUID === "function" 
-         ? crypto.randomUUID() 
-         : Math.random().toString(36).substring(2) + Date.now().toString(36);
 
       setSubmitting(chargeId);
       try {
          const fd = new FormData();
          fd.append("chargeId", chargeId);
-         fd.append("idempotencyKey", idempotency);
+         fd.append("idempotencyKey", idempotencyKey);
          if (!isFullRefund) {
             fd.append("amountCents", String(amountCents));
          }
+         fd.append("customerId", stripeCustomerId)
 
          const result = await createTransactionRefund(null, fd);
 
@@ -463,7 +465,7 @@ export function UserTransactionsModal({
                         )}
                      >
                         {submitting === selectedTransaction.id ? (
-                           <Loader2 className="size-3 animate-spin mr-1.5" />
+                            <Spinner className="size-3 mr-1.5" />
                         ) : null}
                         Refund Partial
                      </Button>
@@ -498,7 +500,7 @@ export function UserTransactionsModal({
             </AlertDialogHeader>
             <AlertDialogFooter>
                <AlertDialogCancel onClick={() => setConfirmRefund(null)}>Cancel</AlertDialogCancel>
-               <AlertDialogAction onClick={executeRefund} className="bg-destructive hover:bg-destructive/90 text-white">
+               <AlertDialogAction variant="destructive" onClick={executeRefund}>
                   Confirm Refund
                </AlertDialogAction>
             </AlertDialogFooter>

--- a/app/(authenticated)/users/_components/components/user-transactions-modals.tsx
+++ b/app/(authenticated)/users/_components/components/user-transactions-modals.tsx
@@ -79,7 +79,7 @@ export function UserTransactionsModal({
    } | null>(null);
 
    const fetchTransactions = React.useCallback(
-      async (params?: { startingAfter?: string; endingBefore?: string }) => {
+      async (params?: { startingAfter?: string }) => {
          if (!stripeCustomerId) return;
          setLoading(true);
          setError(null);
@@ -87,7 +87,6 @@ export function UserTransactionsModal({
             const result = await getUserTransactions({
                customerId: stripeCustomerId,
                startingAfter: params?.startingAfter,
-               endingBefore: params?.endingBefore,
             });
             setTransactions(result.data);
             setHasMore(result.hasMore);

--- a/app/(authenticated)/users/_components/components/user-transactions-modals.tsx
+++ b/app/(authenticated)/users/_components/components/user-transactions-modals.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import * as React from "react";
-import { 
-   Loader2, 
-   ArrowLeft, 
-   ArrowRight 
+import {
+   Loader2,
+   ArrowLeft,
+   ArrowRight,
+   ChevronDown,
+   ChevronRight,
 } from "lucide-react";
 import {
    Dialog,
@@ -76,6 +78,7 @@ export function UserTransactionsModal({
       amountCents: number;
       displayAmount: string;
    } | null>(null);
+   const [expandedIds, setExpandedIds] = React.useState<Set<string>>(new Set());
 
    const fetchTransactions = React.useCallback(
       async (params?: { startingAfter?: string; endingBefore?: string }) => {
@@ -107,10 +110,12 @@ export function UserTransactionsModal({
       if (open && stripeCustomerId) {
          setHistory([]);
          setSelectedTransaction(null);
+         setExpandedIds(new Set());
          fetchTransactions();
       } else if (!open) {
          setTransactions([]);
          setSelectedTransaction(null);
+         setExpandedIds(new Set());
          setError(null);
       }
    }, [open, stripeCustomerId, fetchTransactions]);
@@ -127,6 +132,18 @@ export function UserTransactionsModal({
       const prevCursors = history[history.length - 1];
       setHistory((prev) => prev.slice(0, -1)); 
       await fetchTransactions({ endingBefore: cursors.firstId ?? undefined });
+   };
+
+   const toggleExpanded = (chargeId: string) => {
+      setExpandedIds((prev) => {
+         const next = new Set(prev);
+         if (next.has(chargeId)) {
+            next.delete(chargeId);
+         } else {
+            next.add(chargeId);
+         }
+         return next;
+      });
    };
 
    // Step 1: Validates and prompts the admin via confirmation dialog
@@ -221,6 +238,20 @@ export function UserTransactionsModal({
       }).format(new Date(timestamp * 1000));
    }
 
+   function formatRefundStatus(t: UserTransaction): string {
+      const total = formatAmount(t.amount, t.currency);
+      const remainingCents = t.amount = t.amountRefunded
+      const refundable = formatAmount(remainingCents, t.currency);
+
+      if (t.refunded || remainingCents <= 0) {
+         return "Fully refunded - nothing left to refund";
+      }
+      if (t.amountRefunded > 0){
+         const refunded = formatAmount(t.amountRefunded, t.currency);
+         return `${refunded} refunded of ${total} · ${refundable} refundable — partially refunded`;
+      }
+      return `Paid ${total} — no refunds`;
+   }
 
     return (
         <>
@@ -251,6 +282,7 @@ export function UserTransactionsModal({
                      <Table>
                         <TableHeader>
                            <TableRow>
+                              <TableHead className="w-8" />
                               <TableHead className="text-xs font-medium text-muted-foreground">Date</TableHead>
                               <TableHead className="text-xs font-medium text-muted-foreground">Description</TableHead>
                               <TableHead className="text-xs font-medium text-muted-foreground">Amount</TableHead>
@@ -258,41 +290,70 @@ export function UserTransactionsModal({
                            </TableRow>
                         </TableHeader>
                         <TableBody>
-                           {transactions.map((t) => {
-                              return (
-                                 <TableRow 
-                                    key={t.id} 
+                           {transactions.map((t) => (
+                              <React.Fragment key={t.id}>
+                                 <TableRow
                                     className="hover:bg-muted/10 border-b border-border cursor-pointer"
                                     onClick={() => setSelectedTransaction(t)}
                                     title="Click to view details or issue a refund"
                                  >
-                                    {/* Date */}
+                                    <TableCell className="w-8 p-1">
+                                       {t.refunds.length > 0 ? (
+                                          <Button
+                                             type="button"
+                                             variant="ghost"
+                                             size="icon-sm"
+                                             aria-label={
+                                                expandedIds.has(t.id)
+                                                   ? "Collapse refund history"
+                                                   : "Expand refund history"
+                                             }
+                                             onClick={(e) => {
+                                                e.stopPropagation();
+                                                toggleExpanded(t.id);
+                                             }}
+                                          >
+                                             {expandedIds.has(t.id) ? (
+                                                <ChevronDown className="size-4" />
+                                             ) : (
+                                                <ChevronRight className="size-4" />
+                                             )}
+                                          </Button>
+                                       ) : null}
+                                    </TableCell>
                                     <TableCell className="text-xs font-normal text-muted-foreground whitespace-nowrap">
                                        {formatDate(t.created)}
                                     </TableCell>
-                                    {/* Description */}
                                     <TableCell className="text-xs font-normal text-muted-foreground max-w-[200px] truncate" title={t.description}>
                                        {t.description}
                                     </TableCell>
-                                    {/* Original Amount */}
                                     <TableCell className="text-xs font-normal text-muted-foreground">
                                        {formatAmount(t.amount, t.currency)}
                                     </TableCell>
-                                    {/* Refund Status */}
                                     <TableCell className="text-xs font-normal text-muted-foreground">
-                                       {t.refunded ? (
-                                          <span>Refunded</span>
-                                       ) : t.amountRefunded > 0 ? (
-                                          <span>
-                                             Partially refunded ({formatAmount(t.amountRefunded, t.currency)})
-                                          </span>
-                                       ) : (
-                                          <span>Paid</span>
-                                       )}
+                                       {formatRefundStatus(t)}
                                     </TableCell>
                                  </TableRow>
-                              );
-                           })}
+                                 {expandedIds.has(t.id) && (
+                                    <TableRow className="bg-muted/5 hover:bg-muted/5">
+                                       <TableCell colSpan={5} className="py-2 px-4">
+                                          <ul className="flex flex-col gap-1.5">
+                                             {t.refunds.map((r) => (
+                                                <li
+                                                   key={r.id}
+                                                   className="text-xs text-muted-foreground flex flex-wrap items-center gap-x-3"
+                                                >
+                                                   <span>{formatAmount(r.amount, t.currency)}</span>
+                                                   <span>{formatDate(r.created)}</span>
+                                                   <span className="capitalize">{r.status ?? "unknown"}</span>
+                                                </li>
+                                             ))}
+                                          </ul>
+                                       </TableCell>
+                                    </TableRow>
+                                 )}
+                              </React.Fragment>
+                           ))}
                         </TableBody>
                      </Table>
                   </div>
@@ -362,13 +423,7 @@ export function UserTransactionsModal({
                      <div className="col-span-2">
                         <span className="font-medium text-muted-foreground block mb-0.5">Refund Status</span>
                         <span className="text-foreground">
-                           {selectedTransaction.refunded ? (
-                              "Fully refunded"
-                           ) : selectedTransaction.amountRefunded > 0 ? (
-                              `Partially refunded (${formatAmount(selectedTransaction.amountRefunded, selectedTransaction.currency)})`
-                           ) : (
-                              "Paid"
-                           )}
+                           {formatRefundStatus(selectedTransaction)}
                         </span>
                      </div>
                   </div>

--- a/app/(authenticated)/users/_components/components/user-transactions-modals.tsx
+++ b/app/(authenticated)/users/_components/components/user-transactions-modals.tsx
@@ -1,0 +1,470 @@
+"use client";
+
+import * as React from "react";
+import { 
+   Loader2, 
+   ArrowLeft, 
+   ArrowRight 
+} from "lucide-react";
+import {
+   Dialog,
+   DialogContent,
+   DialogDescription,
+   DialogFooter,
+   DialogHeader,
+   DialogTitle,
+} from "@/components/ui/dialog";
+import {
+   AlertDialog,
+   AlertDialogAction,
+   AlertDialogCancel,
+   AlertDialogContent,
+   AlertDialogDescription,
+   AlertDialogFooter,
+   AlertDialogHeader,
+   AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Spinner } from "@/components/ui/spinner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+   Table,
+   TableBody,
+   TableCell,
+   TableHead,
+   TableHeader,
+   TableRow,
+} from "@/components/ui/table";
+import { toast } from "sonner";
+import { getUserTransactions, createTransactionRefund } from "@/app/(authenticated)/users/actions";
+import type { UserTransaction, TransactionRefund } from "@/app/(authenticated)/users/actions";
+
+export interface UserTransactionsModalProps {
+   userName: string;
+   userEmail: string;
+   stripeCustomerId: string;
+   open: boolean;
+   onOpenChange: (open: boolean) => void;
+}
+
+export function UserTransactionsModal({
+   userName,
+   userEmail,
+   stripeCustomerId,
+   open,
+   onOpenChange,
+}: UserTransactionsModalProps) {
+
+   const [transactions, setTransactions] = React.useState<UserTransaction[]>([]);
+   const [loading, setLoading] = React.useState(false);
+   const [submitting, setSubmitting] = React.useState<string | null>(null);
+   const [error, setError] = React.useState<string | null>(null);
+
+   const [hasMore, setHasMore] = React.useState(false);
+   const [cursors, setCursors] = React.useState<{ firstId: string | null; lastId: string | null }>({
+      firstId: null,
+      lastId: null,
+   });
+   const [history, setHistory] = React.useState<Array<{ firstId: string | null; lastId: string | null }>>([]);
+
+   const [selectedTransaction, setSelectedTransaction] = React.useState<UserTransaction | null>(null);
+   const [refundAmounts, setRefundAmounts] = React.useState<Record<string, string>>({});
+   const [confirmRefund, setConfirmRefund] = React.useState<{
+      chargeId: string;
+      isFullRefund: boolean;
+      amountCents: number;
+      displayAmount: string;
+   } | null>(null);
+
+   const fetchTransactions = React.useCallback(
+      async (params?: { startingAfter?: string; endingBefore?: string }) => {
+         if (!stripeCustomerId) return;
+         setLoading(true);
+         setError(null);
+         try {
+            const result = await getUserTransactions({
+               customerId: stripeCustomerId,
+               startingAfter: params?.startingAfter,
+               endingBefore: params?.endingBefore,
+            });
+            setTransactions(result.data);
+            setHasMore(result.hasMore);
+            setCursors({
+               firstId: result.firstId,
+               lastId: result.lastId,
+            });
+         } catch (err: any) {
+            setError(err.message || "Failed to fetch transactions");
+         } finally {
+            setLoading(false);
+         }
+      },
+      [stripeCustomerId]
+   );
+
+   React.useEffect(() => {
+      if (open && stripeCustomerId) {
+         setHistory([]);
+         setSelectedTransaction(null);
+         fetchTransactions();
+      } else if (!open) {
+         setTransactions([]);
+         setSelectedTransaction(null);
+         setError(null);
+      }
+   }, [open, stripeCustomerId, fetchTransactions]);
+
+
+   const handleNextPage = async () => {
+      if (!cursors.lastId || !hasMore) return;
+      setHistory((prev) => [...prev, cursors]);
+      await fetchTransactions({ startingAfter: cursors.lastId });
+   };
+
+   const handlePrevPage = async () => {
+      if (history.length === 0) return;
+      const prevCursors = history[history.length - 1];
+      setHistory((prev) => prev.slice(0, -1)); 
+      await fetchTransactions({ endingBefore: cursors.firstId ?? undefined });
+   };
+
+   // Step 1: Validates and prompts the admin via confirmation dialog
+   const initiateRefund = (chargeId: string, isFullRefund: boolean, maxRefundableCents: number, currency: string) => {
+      let refundAmountCents = maxRefundableCents;
+      let displayAmount = formatAmount(maxRefundableCents, currency);
+
+      if (!isFullRefund) {
+         const rawAmount = refundAmounts[chargeId] || "";
+         const parsedAmount = parseFloat(rawAmount);
+         if (isNaN(parsedAmount) || parsedAmount <= 0) {
+            toast.error("Please enter a valid refund amount");
+            return;
+         }
+
+         refundAmountCents = Math.round(parsedAmount * 100);
+         if (refundAmountCents > maxRefundableCents) {
+            toast.error(`Refund amount cannot exceed remaining refundable balance (${formatAmount(maxRefundableCents, currency)})`);
+            return;
+         }
+         displayAmount = formatAmount(refundAmountCents, currency);
+      }
+
+      setConfirmRefund({
+         chargeId,
+         isFullRefund,
+         amountCents: refundAmountCents,
+         displayAmount,
+      });
+   };
+
+   // Step 2: Executes the refund Server Action after confirmation
+   const executeRefund = async () => {
+      if (!confirmRefund) return;
+      const { chargeId, isFullRefund, amountCents } = confirmRefund;
+      setConfirmRefund(null); // Close confirmation immediately
+
+      const idempotency = typeof crypto.randomUUID === "function" 
+         ? crypto.randomUUID() 
+         : Math.random().toString(36).substring(2) + Date.now().toString(36);
+
+      setSubmitting(chargeId);
+      try {
+         const fd = new FormData();
+         fd.append("chargeId", chargeId);
+         fd.append("idempotencyKey", idempotency);
+         if (!isFullRefund) {
+            fd.append("amountCents", String(amountCents));
+         }
+
+         const result = await createTransactionRefund(null, fd);
+
+         if (result?.errors) {
+            toast.error("Refund failed", {
+               description: Object.values(result.errors).flat().join(" "),
+            });
+         } else if (result?.status === "succeeded") {
+            const formattedAmount = formatAmount(amountCents, result.updatedTransaction?.currency || "cad");
+            toast.success(`Refunded ${formattedAmount}`);
+
+            setRefundAmounts((prev) => ({ ...prev, [chargeId]: "" }));
+
+            if (result.updatedTransaction) {
+               setTransactions((prev) =>
+                  prev.map((t) => (t.id === chargeId ? result.updatedTransaction! : t))
+               );
+               setSelectedTransaction(result.updatedTransaction);
+            }
+         } else if (result?.status === "pending") {
+            toast.info("Refund pending. The transaction will reconcile shortly.");
+         }
+      } catch (err: any) {
+         toast.error(err.message || "Failed to process refund");
+      } finally {
+         setSubmitting(null);
+      }
+   };
+
+   function formatAmount(cents: number, currency: string) {
+      const dollars = cents / 100;
+      return new Intl.NumberFormat("en-CA", {
+         style: "currency",
+         currency: currency.toUpperCase(),
+      }).format(dollars);
+   }
+
+   function formatDate(timestamp: number) {
+      return new Intl.DateTimeFormat("en-CA", {
+         year: "numeric",
+         month: "short",
+         day: "numeric",
+      }).format(new Date(timestamp * 1000));
+   }
+
+
+    return (
+        <>
+            <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="sm:max-w-2xl">
+                <DialogHeader>
+                <DialogTitle>User transactions</DialogTitle>
+                <DialogDescription>
+                    {userName && userName.trim() !== userEmail ? `${userName} (${userEmail})` : userEmail}
+                </DialogDescription>
+                </DialogHeader>
+                <div className="h-[222px] min-h-[222px] max-h-[222px] overflow-y-auto my-2 flex flex-col justify-start">
+                {loading && transactions.length === 0 ? (
+                    <div className="flex flex-col items-center justify-center h-full gap-2 text-muted-foreground py-10">
+                        <Spinner className="size-6" />
+                        <p className="text-xs">Loading transaction history...</p>
+                    </div>
+                ) : error ? (
+                    <div className="flex items-center justify-center h-full text-destructive text-xs font-semibold py-10">
+                        {error}
+                    </div>
+                ) : transactions.length === 0 ? (
+                    <div className="flex items-center justify-center h-full text-muted-foreground text-xs py-10">
+                        No transactions found for this customer on Stripe.
+                    </div>
+                ) : (
+                    <div className="w-full rounded-lg border border-border overflow-hidden">
+                     <Table>
+                        <TableHeader>
+                           <TableRow>
+                              <TableHead className="text-xs font-medium text-muted-foreground">Date</TableHead>
+                              <TableHead className="text-xs font-medium text-muted-foreground">Description</TableHead>
+                              <TableHead className="text-xs font-medium text-muted-foreground">Amount</TableHead>
+                              <TableHead className="text-xs font-medium text-muted-foreground">Refund Status</TableHead>
+                           </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                           {transactions.map((t) => {
+                              return (
+                                 <TableRow 
+                                    key={t.id} 
+                                    className="hover:bg-muted/10 border-b border-border cursor-pointer"
+                                    onClick={() => setSelectedTransaction(t)}
+                                    title="Click to view details or issue a refund"
+                                 >
+                                    {/* Date */}
+                                    <TableCell className="text-xs font-normal text-muted-foreground whitespace-nowrap">
+                                       {formatDate(t.created)}
+                                    </TableCell>
+                                    {/* Description */}
+                                    <TableCell className="text-xs font-normal text-muted-foreground max-w-[200px] truncate" title={t.description}>
+                                       {t.description}
+                                    </TableCell>
+                                    {/* Original Amount */}
+                                    <TableCell className="text-xs font-normal text-muted-foreground">
+                                       {formatAmount(t.amount, t.currency)}
+                                    </TableCell>
+                                    {/* Refund Status */}
+                                    <TableCell className="text-xs font-normal text-muted-foreground">
+                                       {t.refunded ? (
+                                          <span>Refunded</span>
+                                       ) : t.amountRefunded > 0 ? (
+                                          <span>
+                                             Partially refunded ({formatAmount(t.amountRefunded, t.currency)})
+                                          </span>
+                                       ) : (
+                                          <span>Paid</span>
+                                       )}
+                                    </TableCell>
+                                 </TableRow>
+                              );
+                           })}
+                        </TableBody>
+                     </Table>
+                  </div>
+
+                )}
+                </div>
+            <DialogFooter className="flex flex-row items-center justify-between sm:justify-between gap-2">
+               <div className="flex items-center gap-1">
+                  <Button
+                     type="button"
+                     variant="ghost"
+                     size="sm"
+                     disabled={history.length === 0 || loading}
+                     onClick={handlePrevPage}
+                  >
+                     <ArrowLeft className="size-4 mr-1" />
+                     Previous
+                  </Button>
+                  <Button
+                     type="button"
+                     variant="ghost"
+                     size="sm"
+                     disabled={!hasMore || loading}
+                     onClick={handleNextPage}
+                  >
+                     Next
+                     <ArrowRight className="size-4 ml-1" />
+                  </Button>
+               </div>
+               <Button
+                  type="button"
+                  onClick={() => onOpenChange(false)}
+               >
+                  Close
+               </Button>
+            </DialogFooter>
+         </DialogContent>
+      </Dialog>
+
+      {/* Transaction Details & Refund Dialog */}
+      <Dialog open={selectedTransaction !== null} onOpenChange={(isOpen) => !isOpen && setSelectedTransaction(null)}>
+         <DialogContent className="sm:max-w-md">
+            <DialogHeader>
+               <DialogTitle>Refund Transaction</DialogTitle>
+               <DialogDescription>
+                  Manage refunds for this transaction.
+               </DialogDescription>
+            </DialogHeader>
+
+            {selectedTransaction && (
+               <div className="flex flex-col gap-4 py-2">
+                  <div className="grid grid-cols-2 gap-4 border-b border-border pb-4 text-xs">
+                     <div>
+                        <span className="font-medium text-muted-foreground block mb-0.5">Date</span>
+                        <span className="text-foreground">{formatDate(selectedTransaction.created)}</span>
+                     </div>
+                     <div>
+                        <span className="font-medium text-muted-foreground block mb-0.5">Amount</span>
+                        <span className="text-foreground">{formatAmount(selectedTransaction.amount, selectedTransaction.currency)}</span>
+                     </div>
+                     <div className="col-span-2">
+                        <span className="font-medium text-muted-foreground block mb-0.5">Description</span>
+                        <span className="text-foreground truncate block" title={selectedTransaction.description}>
+                           {selectedTransaction.description}
+                        </span>
+                     </div>
+                     <div className="col-span-2">
+                        <span className="font-medium text-muted-foreground block mb-0.5">Refund Status</span>
+                        <span className="text-foreground">
+                           {selectedTransaction.refunded ? (
+                              "Fully refunded"
+                           ) : selectedTransaction.amountRefunded > 0 ? (
+                              `Partially refunded (${formatAmount(selectedTransaction.amountRefunded, selectedTransaction.currency)})`
+                           ) : (
+                              "Paid"
+                           )}
+                        </span>
+                     </div>
+                  </div>
+
+                  {/* Refund Inputs */}
+                  {(selectedTransaction.amount - selectedTransaction.amountRefunded) > 0 ? (
+                     <div className="flex flex-col gap-3">
+                        <div className="flex flex-col gap-1.5">
+                           <Label htmlFor={`refund-amount-${selectedTransaction.id}`} className="text-xs text-muted-foreground">
+                              Partial Refund Amount ($)
+                           </Label>
+                           <Input
+                              id={`refund-amount-${selectedTransaction.id}`}
+                              type="number"
+                              step="0.01"
+                              min="0.01"
+                              max={((selectedTransaction.amount - selectedTransaction.amountRefunded) / 100).toFixed(2)}
+                              placeholder="0.00"
+                              value={refundAmounts[selectedTransaction.id] || ""}
+                              disabled={submitting === selectedTransaction.id}
+                              onChange={(e) => setRefundAmounts({ ...refundAmounts, [selectedTransaction.id]: e.target.value })}
+                              className="h-9 text-xs"
+                           />
+                        </div>
+                     </div>
+                  ) : (
+                     <p className="text-xs text-muted-foreground italic text-center py-2">
+                        No further refunds can be issued for this charge.
+                     </p>
+                  )}
+               </div>
+            )}
+
+            <DialogFooter>
+               <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setSelectedTransaction(null)}
+                  disabled={selectedTransaction ? submitting === selectedTransaction.id : false}
+               >
+                  Cancel
+               </Button>
+               {selectedTransaction && (selectedTransaction.amount - selectedTransaction.amountRefunded) > 0 && (
+                  <>
+                     <Button
+                        type="button"
+                        disabled={submitting === selectedTransaction.id}
+                        onClick={() => initiateRefund(
+                           selectedTransaction.id,
+                           false,
+                           selectedTransaction.amount - selectedTransaction.amountRefunded,
+                           selectedTransaction.currency
+                        )}
+                     >
+                        {submitting === selectedTransaction.id ? (
+                           <Loader2 className="size-3 animate-spin mr-1.5" />
+                        ) : null}
+                        Refund Partial
+                     </Button>
+                     <Button
+                        type="button"
+                        variant="destructive"
+                        disabled={submitting === selectedTransaction.id}
+                        onClick={() => initiateRefund(
+                           selectedTransaction.id,
+                           true,
+                           selectedTransaction.amount - selectedTransaction.amountRefunded,
+                           selectedTransaction.currency
+                        )}
+                     >
+                        Refund Full
+                     </Button>
+                  </>
+               )}
+            </DialogFooter>
+         </DialogContent>
+      </Dialog>
+
+      {/* Refund Confirmation Alert Dialog */}
+      <AlertDialog open={confirmRefund !== null} onOpenChange={(isOpen) => !isOpen && setConfirmRefund(null)}>
+         <AlertDialogContent size="default">
+            <AlertDialogHeader>
+               <AlertDialogTitle>Confirm Refund</AlertDialogTitle>
+               <AlertDialogDescription>
+                  Are you sure you want to issue a {confirmRefund?.isFullRefund ? "full" : "partial"} refund of{" "}
+                  <span className="font-bold text-foreground">{confirmRefund?.displayAmount}</span>? This action will transfer money back to the customer on Stripe and cannot be undone.
+               </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+               <AlertDialogCancel onClick={() => setConfirmRefund(null)}>Cancel</AlertDialogCancel>
+               <AlertDialogAction onClick={executeRefund} className="bg-destructive hover:bg-destructive/90 text-white">
+                  Confirm Refund
+               </AlertDialogAction>
+            </AlertDialogFooter>
+         </AlertDialogContent>
+      </AlertDialog>
+   </>
+);
+}

--- a/app/(authenticated)/users/_components/components/user-transactions-modals.tsx
+++ b/app/(authenticated)/users/_components/components/user-transactions-modals.tsx
@@ -125,8 +125,16 @@ export function UserTransactionsModal({
 
    const handlePrevPage = async () => {
       if (history.length === 0) return;
-      setHistory((prev) => prev.slice(0, -1)); 
-      await fetchTransactions({ endingBefore: cursors.firstId ?? undefined });
+
+      const newHistory = history.slice(0, -1);
+      setHistory(newHistory);
+
+      if (newHistory.length === 0) {
+         await fetchTransactions();
+      } else {
+         const prevPageCursors = newHistory[newHistory.length - 1];
+         await fetchTransactions({ startingAfter: prevPageCursors.lastId ?? undefined });
+      }
    };
 
    // Step 1: Validates and prompts the admin via confirmation dialog

--- a/app/(authenticated)/users/_components/components/user-transactions-modals.tsx
+++ b/app/(authenticated)/users/_components/components/user-transactions-modals.tsx
@@ -95,8 +95,8 @@ export function UserTransactionsModal({
                firstId: result.firstId,
                lastId: result.lastId,
             });
-         } catch (err: any) {
-            setError(err.message || "Failed to fetch transactions");
+         } catch (err) {
+            setError(err instanceof Error ? err.message : "Failed to fetch transactions");
          } finally {
             setLoading(false);
          }
@@ -125,7 +125,6 @@ export function UserTransactionsModal({
 
    const handlePrevPage = async () => {
       if (history.length === 0) return;
-      const prevCursors = history[history.length - 1];
       setHistory((prev) => prev.slice(0, -1)); 
       await fetchTransactions({ endingBefore: cursors.firstId ?? undefined });
    };
@@ -199,8 +198,8 @@ export function UserTransactionsModal({
          } else if (result?.status === "pending") {
             toast.info("Refund pending. The transaction will reconcile shortly.");
          }
-      } catch (err: any) {
-         toast.error(err.message || "Failed to process refund");
+      } catch (err) {
+         toast.error(err instanceof Error ? err.message : "Failed to process refund");
       } finally {
          setSubmitting(null);
       }

--- a/app/(authenticated)/users/_components/components/user-transactions-modals.tsx
+++ b/app/(authenticated)/users/_components/components/user-transactions-modals.tsx
@@ -5,8 +5,6 @@ import {
    Loader2,
    ArrowLeft,
    ArrowRight,
-   ChevronDown,
-   ChevronRight,
 } from "lucide-react";
 import {
    Dialog,
@@ -39,8 +37,9 @@ import {
    TableRow,
 } from "@/components/ui/table";
 import { toast } from "sonner";
+import { cn } from "@/lib/utils";
 import { getUserTransactions, createTransactionRefund } from "@/app/(authenticated)/users/actions";
-import type { UserTransaction, TransactionRefund } from "@/app/(authenticated)/users/actions";
+import type { UserTransaction } from "@/app/(authenticated)/users/actions";
 
 export interface UserTransactionsModalProps {
    userName: string;
@@ -78,7 +77,6 @@ export function UserTransactionsModal({
       amountCents: number;
       displayAmount: string;
    } | null>(null);
-   const [expandedIds, setExpandedIds] = React.useState<Set<string>>(new Set());
 
    const fetchTransactions = React.useCallback(
       async (params?: { startingAfter?: string; endingBefore?: string }) => {
@@ -110,12 +108,10 @@ export function UserTransactionsModal({
       if (open && stripeCustomerId) {
          setHistory([]);
          setSelectedTransaction(null);
-         setExpandedIds(new Set());
          fetchTransactions();
       } else if (!open) {
          setTransactions([]);
          setSelectedTransaction(null);
-         setExpandedIds(new Set());
          setError(null);
       }
    }, [open, stripeCustomerId, fetchTransactions]);
@@ -132,18 +128,6 @@ export function UserTransactionsModal({
       const prevCursors = history[history.length - 1];
       setHistory((prev) => prev.slice(0, -1)); 
       await fetchTransactions({ endingBefore: cursors.firstId ?? undefined });
-   };
-
-   const toggleExpanded = (chargeId: string) => {
-      setExpandedIds((prev) => {
-         const next = new Set(prev);
-         if (next.has(chargeId)) {
-            next.delete(chargeId);
-         } else {
-            next.add(chargeId);
-         }
-         return next;
-      });
    };
 
    // Step 1: Validates and prompts the admin via confirmation dialog
@@ -240,10 +224,10 @@ export function UserTransactionsModal({
 
    function formatRefundStatus(t: UserTransaction): string {
       const total = formatAmount(t.amount, t.currency);
-      const remainingCents = t.amount = t.amountRefunded
+      const remainingCents = t.amount - t.amountRefunded
       const refundable = formatAmount(remainingCents, t.currency);
 
-      if (t.refunded || remainingCents <= 0) {
+      if (t.refunded || (t.amountRefunded > 0 && remainingCents <= 0)) {
          return "Fully refunded - nothing left to refund";
       }
       if (t.amountRefunded > 0){
@@ -251,6 +235,18 @@ export function UserTransactionsModal({
          return `${refunded} refunded of ${total} · ${refundable} refundable — partially refunded`;
       }
       return `Paid ${total} — no refunds`;
+   }
+
+   function formatRefundStatusShort(t: UserTransaction): string {
+      const remainingCents = t.amount - t.amountRefunded;
+
+      if (t.refunded || (t.amountRefunded > 0 && remainingCents <= 0)) {
+         return "Fully refunded";
+      }
+      if (t.amountRefunded > 0) {
+         return "Partially refunded";
+      }
+      return "Paid";
    }
 
     return (
@@ -282,7 +278,6 @@ export function UserTransactionsModal({
                      <Table>
                         <TableHeader>
                            <TableRow>
-                              <TableHead className="w-8" />
                               <TableHead className="text-xs font-medium text-muted-foreground">Date</TableHead>
                               <TableHead className="text-xs font-medium text-muted-foreground">Description</TableHead>
                               <TableHead className="text-xs font-medium text-muted-foreground">Amount</TableHead>
@@ -291,36 +286,12 @@ export function UserTransactionsModal({
                         </TableHeader>
                         <TableBody>
                            {transactions.map((t) => (
-                              <React.Fragment key={t.id}>
                                  <TableRow
+                                    key={t.id}
                                     className="hover:bg-muted/10 border-b border-border cursor-pointer"
                                     onClick={() => setSelectedTransaction(t)}
                                     title="Click to view details or issue a refund"
                                  >
-                                    <TableCell className="w-8 p-1">
-                                       {t.refunds.length > 0 ? (
-                                          <Button
-                                             type="button"
-                                             variant="ghost"
-                                             size="icon-sm"
-                                             aria-label={
-                                                expandedIds.has(t.id)
-                                                   ? "Collapse refund history"
-                                                   : "Expand refund history"
-                                             }
-                                             onClick={(e) => {
-                                                e.stopPropagation();
-                                                toggleExpanded(t.id);
-                                             }}
-                                          >
-                                             {expandedIds.has(t.id) ? (
-                                                <ChevronDown className="size-4" />
-                                             ) : (
-                                                <ChevronRight className="size-4" />
-                                             )}
-                                          </Button>
-                                       ) : null}
-                                    </TableCell>
                                     <TableCell className="text-xs font-normal text-muted-foreground whitespace-nowrap">
                                        {formatDate(t.created)}
                                     </TableCell>
@@ -331,28 +302,9 @@ export function UserTransactionsModal({
                                        {formatAmount(t.amount, t.currency)}
                                     </TableCell>
                                     <TableCell className="text-xs font-normal text-muted-foreground">
-                                       {formatRefundStatus(t)}
+                                       {formatRefundStatusShort(t)}
                                     </TableCell>
                                  </TableRow>
-                                 {expandedIds.has(t.id) && (
-                                    <TableRow className="bg-muted/5 hover:bg-muted/5">
-                                       <TableCell colSpan={5} className="py-2 px-4">
-                                          <ul className="flex flex-col gap-1.5">
-                                             {t.refunds.map((r) => (
-                                                <li
-                                                   key={r.id}
-                                                   className="text-xs text-muted-foreground flex flex-wrap items-center gap-x-3"
-                                                >
-                                                   <span>{formatAmount(r.amount, t.currency)}</span>
-                                                   <span>{formatDate(r.created)}</span>
-                                                   <span className="capitalize">{r.status ?? "unknown"}</span>
-                                                </li>
-                                             ))}
-                                          </ul>
-                                       </TableCell>
-                                    </TableRow>
-                                 )}
-                              </React.Fragment>
                            ))}
                         </TableBody>
                      </Table>
@@ -427,6 +379,32 @@ export function UserTransactionsModal({
                         </span>
                      </div>
                   </div>
+
+                  {selectedTransaction.refunds.length > 0 && (
+                     <div className="flex flex-col gap-1.5 border-b border-border pb-4">
+                        <span className="text-xs font-medium text-muted-foreground">
+                           Refund history
+                        </span>
+                        <ul
+                           className={cn(
+                              "flex flex-col gap-1.5",
+                              selectedTransaction.refunds.length > 3 &&
+                                 "max-h-[4.5rem] overflow-y-auto pr-1"
+                           )}
+                        >
+                           {selectedTransaction.refunds.map((r) => (
+                              <li
+                                 key={r.id}
+                                 className="text-xs text-muted-foreground flex items-center gap-x-3"
+                              >
+                                 <span>{formatAmount(r.amount, selectedTransaction.currency)}</span>
+                                 <span>{formatDate(r.created)}</span>
+                                 <span className="capitalize">{r.status ?? "unknown"}</span>
+                              </li>
+                           ))}
+                        </ul>
+                     </div>
+                  )}
 
                   {/* Refund Inputs */}
                   {(selectedTransaction.amount - selectedTransaction.amountRefunded) > 0 ? (

--- a/app/(authenticated)/users/_components/user-actions-cell.tsx
+++ b/app/(authenticated)/users/_components/user-actions-cell.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useRef, useState } from "react";
-import { Pencil, Tag, Trash2 } from "lucide-react";
+
+import { Pencil, Tag, Trash2, ReceiptText } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
@@ -24,6 +25,8 @@ import {
 import { deleteUserAdmin } from "@/app/(authenticated)/users/actions";
 import { toast } from "sonner";
 import { profileRoleLabel, type UserRow } from "../profile-role-label";
+import { UserTransactionsModal } from "./components/user-transactions-modals";
+
 
 interface UserActionsCellProps {
    user: UserRow;
@@ -31,6 +34,7 @@ interface UserActionsCellProps {
 }
 
 export function UserActionsCell({ user, onEdit }: UserActionsCellProps) {
+   const [txOpen, setTxOpen] = useState(false);
    const [open, setOpen] = useState(false);
    const [services, setServices] = useState<DiscountService[]>([]);
    const [discounts, setDiscounts] = useState<ActiveDiscount[]>([]);
@@ -148,6 +152,22 @@ export function UserActionsCell({ user, onEdit }: UserActionsCellProps) {
                {user.stripeCustomerId ? "Manage discounts" : "No Stripe customer"}
             </TooltipContent>
          </Tooltip>
+         <Tooltip>
+            <TooltipTrigger asChild>
+               <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label="View transactions"
+                  disabled={!user.stripeCustomerId}
+                  onClick={() => setTxOpen(true)}
+               >
+                  <ReceiptText />
+               </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+               {user.stripeCustomerId ? "View transactions" : "No Stripe customer"}
+            </TooltipContent>
+         </Tooltip>
          <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
             <Tooltip>
                <TooltipTrigger asChild>
@@ -199,6 +219,13 @@ export function UserActionsCell({ user, onEdit }: UserActionsCellProps) {
             onOpenChange={handleOpenChange}
             onApply={handleApply}
             onRemove={handleRemove}
+         />
+         <UserTransactionsModal
+            userName={`${user.firstName} ${user.lastName}`}
+            userEmail={user.email}
+            stripeCustomerId={user.stripeCustomerId || ""}
+            open={txOpen}
+            onOpenChange={setTxOpen}
          />
       </div>
    );

--- a/app/(authenticated)/users/actions.test.ts
+++ b/app/(authenticated)/users/actions.test.ts
@@ -1,0 +1,180 @@
+/**
+ * @jest-environment node
+ */
+import {
+    getUserTransactions,
+    createTransactionRefund,
+ } from "./actions";
+ 
+ const chargesList = jest.fn();
+ const chargesRetrieve = jest.fn();
+ const refundsCreate = jest.fn();
+ const requireAdmin = jest.fn();
+ 
+ jest.mock("@/lib/stripe", () => ({
+    stripe: {
+       charges: {
+          list: (...args: unknown[]) => chargesList(...args),
+          retrieve: (...args: unknown[]) => chargesRetrieve(...args),
+       },
+       refunds: {
+          create: (...args: unknown[]) => refundsCreate(...args),
+       },
+    },
+ }));
+ 
+ jest.mock("@/lib/auth/require-admin", () => ({
+    requireAdmin: (...args: unknown[]) => requireAdmin(...args),
+ }));
+ 
+ function refundFormData(fields: Record<string, string>) {
+    const fd = new FormData();
+    for (const [key, value] of Object.entries(fields)) {
+       fd.append(key, value);
+    }
+    return fd;
+ }
+ 
+ const sampleCharge = {
+    id: "ch_test",
+    amount: 5000,
+    amount_refunded: 0,
+    refunded: false,
+    created: 1700000000,
+    currency: "cad",
+    description: "Yearly plan",
+    payment_intent: "pi_test",
+    refunds: { data: [] },
+    metadata: {},
+ };
+ 
+ beforeEach(() => {
+    jest.clearAllMocks();
+    requireAdmin.mockResolvedValue(undefined);
+ });
+ 
+ describe("getUserTransactions", () => {
+    it("requires admin", async () => {
+       requireAdmin.mockRejectedValue(new Error("Forbidden"));
+ 
+       await expect(
+          getUserTransactions({ customerId: "cus_123" }),
+       ).rejects.toThrow("Forbidden");
+ 
+       expect(chargesList).not.toHaveBeenCalled();
+    });
+ 
+    it("maps charges from Stripe", async () => {
+       chargesList.mockResolvedValue({
+          data: [sampleCharge],
+          has_more: false,
+       });
+ 
+       const result = await getUserTransactions({ customerId: "cus_123" });
+ 
+       expect(chargesList).toHaveBeenCalledWith(
+          expect.objectContaining({ customer: "cus_123", limit: 10 }),
+       );
+       expect(result.data[0]).toMatchObject({
+          id: "ch_test",
+          amount: 5000,
+          description: "Yearly plan",
+          currency: "cad",
+       });
+       expect(result.hasMore).toBe(false);
+    });
+ });
+ 
+ describe("createTransactionRefund", () => {
+    it("returns unauthorized when not admin", async () => {
+       requireAdmin.mockRejectedValue(new Error("Forbidden"));
+ 
+       const result = await createTransactionRefund(
+          null,
+          refundFormData({ chargeId: "ch_test", idempotencyKey: "key-1" }),
+       );
+ 
+       expect(result).toEqual({ errors: { _form: ["Unauthorized"] } });
+       expect(chargesRetrieve).not.toHaveBeenCalled();
+    });
+ 
+    it("rejects when charge is already fully refunded", async () => {
+       chargesRetrieve.mockResolvedValue({
+          amount: 5000,
+          amount_refunded: 5000,
+       });
+ 
+       const result = await createTransactionRefund(
+          null,
+          refundFormData({ chargeId: "ch_test", idempotencyKey: "key-1" }),
+       );
+ 
+       expect(result?.errors?._form).toContain(
+          "This charge is already fully refunded.",
+       );
+       expect(refundsCreate).not.toHaveBeenCalled();
+    });
+ 
+    it("rejects partial refund above remaining balance", async () => {
+       chargesRetrieve.mockResolvedValue({
+          amount: 5000,
+          amount_refunded: 1000,
+       });
+ 
+       const result = await createTransactionRefund(
+          null,
+          refundFormData({
+             chargeId: "ch_test",
+             idempotencyKey: "key-1",
+             amountCents: "5000",
+          }),
+       );
+ 
+       expect(result?.errors?._form).toContain(
+          "Refund amount exceeds the remaining refundable balance.",
+       );
+       expect(refundsCreate).not.toHaveBeenCalled();
+    });
+ 
+    it("issues a full refund and returns updated transaction", async () => {
+       chargesRetrieve
+          .mockResolvedValueOnce({
+             amount: 5000,
+             amount_refunded: 0,
+          })
+          .mockResolvedValueOnce({
+             ...sampleCharge,
+             amount_refunded: 5000,
+             refunded: true,
+             refunds: {
+                data: [
+                   {
+                      id: "re_test",
+                      amount: 5000,
+                      status: "succeeded",
+                      created: 1700000001,
+                   },
+                ],
+             },
+          });
+ 
+       refundsCreate.mockResolvedValue({
+          id: "re_test",
+          amount: 5000,
+          status: "succeeded",
+          created: 1700000001,
+       });
+ 
+       const result = await createTransactionRefund(
+          null,
+          refundFormData({ chargeId: "ch_test", idempotencyKey: "key-1" }),
+       );
+ 
+       expect(refundsCreate).toHaveBeenCalledWith(
+          { charge: "ch_test" },
+          { idempotencyKey: "key-1" },
+       );
+       expect(result?.status).toBe("succeeded");
+       expect(result?.updatedTransaction?.amountRefunded).toBe(5000);
+    });
+ });

--- a/app/(authenticated)/users/actions.test.ts
+++ b/app/(authenticated)/users/actions.test.ts
@@ -27,14 +27,19 @@ import {
     requireAdmin: (...args: unknown[]) => requireAdmin(...args),
  }));
  
+ const CUSTOMER_ID = "cus_123";
+
  function refundFormData(fields: Record<string, string>) {
     const fd = new FormData();
-    for (const [key, value] of Object.entries(fields)) {
+    for (const [key, value] of Object.entries({
+       customerId: CUSTOMER_ID,
+       ...fields,
+    })) {
        fd.append(key, value);
     }
     return fd;
  }
- 
+
  const sampleCharge = {
     id: "ch_test",
     amount: 5000,
@@ -98,8 +103,27 @@ import {
        expect(chargesRetrieve).not.toHaveBeenCalled();
     });
  
+    it("rejects when charge belongs to a different customer", async () => {
+       chargesRetrieve.mockResolvedValue({
+          customer: "cus_other",
+          amount: 5000,
+          amount_refunded: 0,
+       });
+
+       const result = await createTransactionRefund(
+          null,
+          refundFormData({ chargeId: "ch_test", idempotencyKey: "key-1" }),
+       );
+
+       expect(result?.errors?._form).toContain(
+          "Charge does not belong to this customer.",
+       );
+       expect(refundsCreate).not.toHaveBeenCalled();
+    });
+
     it("rejects when charge is already fully refunded", async () => {
        chargesRetrieve.mockResolvedValue({
+          customer: CUSTOMER_ID,
           amount: 5000,
           amount_refunded: 5000,
        });
@@ -117,6 +141,7 @@ import {
  
     it("rejects partial refund above remaining balance", async () => {
        chargesRetrieve.mockResolvedValue({
+          customer: CUSTOMER_ID,
           amount: 5000,
           amount_refunded: 1000,
        });
@@ -139,11 +164,13 @@ import {
     it("issues a full refund and returns updated transaction", async () => {
        chargesRetrieve
           .mockResolvedValueOnce({
+             customer: CUSTOMER_ID,
              amount: 5000,
              amount_refunded: 0,
           })
           .mockResolvedValueOnce({
              ...sampleCharge,
+             customer: CUSTOMER_ID,
              amount_refunded: 5000,
              refunded: true,
              refunds: {

--- a/app/(authenticated)/users/actions.ts
+++ b/app/(authenticated)/users/actions.ts
@@ -10,13 +10,23 @@ import { createAdminClient } from "@/utils/supabase/admin";
 import type { Role } from "@/lib/roles";
 import { ROLES } from "@/lib/roles";
 import { createUserAdminSchema, updateUserAdminSchema } from "./schema";
-import { grantComplimentarySubscription } from "@/lib/stripe";
+import { grantComplimentarySubscription , stripe} from "@/lib/stripe";
+import type Stripe from "stripe";
+import { getTransactionsSchema, createRefundSchema} from "./schema";
 
 export type UserAdminActionState = {
    errors?: Record<string, string[]>;
    message?: string;
    data?: Record<string, string>;
 } | null;
+
+export type RefundActionState = {
+   errors?: Record<string, string[]>;
+   message?: string;
+   status?: "succeeded" | "pending" | "failed";
+   refund?: TransactionRefund;
+   updatedTransaction? : UserTransaction;
+} | null
 
 const USERS_PATH = "/users";
 
@@ -245,4 +255,201 @@ export async function deleteUserAdmin(
 
    revalidatePath(USERS_PATH);
    return { message: "User deleted." };
+}
+
+export type TransactionRefund = {
+   id:string;
+   amount: number;
+   status:string | null;
+   created:number;
+}
+
+export type UserTransaction = {
+   id: string;
+   amount: number;
+   amountRefunded: number;
+   refunded: boolean;
+   created: number;
+   description: string;
+   paymentIntentId: string| null;
+   refunds: TransactionRefund[];
+   currency: string;
+}
+
+export type PaginatedTransactions = {
+   data: UserTransaction[];
+   hasMore: boolean;
+   firstId: string | null;
+   lastId: string | null;
+};
+
+export async function getUserTransactions(
+   input: {
+      customerId: string;
+      limit?:number;
+      startingAfter?: string;
+      endingBefore?:string;
+   }
+): Promise<PaginatedTransactions> {
+   await requireAdmin();
+
+   const parsed = getTransactionsSchema.parse(input)
+
+   const params: Stripe.ChargeListParams = {
+      customer: parsed.customerId,
+      limit: parsed.limit,
+      expand: ["data.refunds", "data.payment_intent"]
+   };
+
+   if(parsed.startingAfter){
+      params.starting_after = parsed.startingAfter;
+   } else if (parsed.endingBefore) {
+      params.ending_before = parsed.endingBefore;
+   }
+
+   const charges = await stripe.charges.list(params)
+
+   const data: UserTransaction[] = charges.data.map((charge)=> {
+      let description = charge.description || "";
+      if (!description && charge.payment_intent && typeof charge.payment_intent !== "string") {
+         description = 
+            charge.payment_intent.description ||
+            charge.payment_intent.metadata?.productName ||
+            charge.payment_intent.metadata?.description ||
+            ""
+         
+      }
+      if(!description) {
+         description = charge.metadata?.productName || charge.metadata?.description || "Payment";
+      }
+
+      const refunds = 
+         (charge as any).refunds?.data?.map((r:Stripe.Refund)=> ({
+            id: r.id,
+            amount: r.amount,
+            status: r.status,
+            created: r.created,
+         })) || [];
+
+      return {
+         id: charge.id,
+         amount: charge.amount,
+         amountRefunded: charge.amount_refunded,
+         refunded: charge.refunded,
+         created: charge.created,
+         description,
+         paymentIntentId:
+            typeof charge.payment_intent === "string" ? charge.payment_intent : charge.payment_intent?.id || null,
+         refunds,
+         currency: charge.currency
+      }
+
+   })
+
+   return {
+      data, 
+      hasMore: charges.has_more,
+      firstId: charges.data[0]?.id || null,
+      lastId: charges.data[charges.data.length -1]?.id || null
+   }
+}
+
+export async function createTransactionRefund(
+  _prev: RefundActionState,
+  formData: FormData
+): Promise<RefundActionState> {
+   try {
+      await requireAdmin();
+   } catch {
+      return {errors : { _form : ["Unauthorized"]}};
+   }
+
+   const amountRaw = formData.get("amountCents");
+   const amountCents = amountRaw? Number(amountRaw): undefined;
+
+   const parsed = createRefundSchema.safeParse({
+      chargeId: formData.get("chargeId"),
+      amountCents,
+      idempotencyKey: formData.get("idempotencyKey"),
+   });
+
+   if (!parsed.success) {
+      return {errors : parsed.error.flatten().fieldErrors};
+   }
+   const {chargeId, amountCents: refundAmount, idempotencyKey} = parsed.data;
+
+
+   try {
+      const refundParams: Stripe.RefundCreateParams = {
+         charge:chargeId,
+      };
+
+      if (refundAmount !== undefined) {
+         refundParams.amount = refundAmount;
+      }
+
+      const refund = await stripe.refunds.create(refundParams, { idempotencyKey
+      })
+
+      const updatedCharge = await stripe.charges.retrieve(chargeId, {
+         expand: [ "refunds", "payment_intent"],
+      })
+
+      let description = updatedCharge.description || "";
+      if (!description && updatedCharge.payment_intent && typeof updatedCharge.payment_intent !== "string") {
+         description =
+            updatedCharge.payment_intent.description ||
+            updatedCharge.payment_intent.metadata?.productName ||
+            updatedCharge.payment_intent.metadata?.description ||
+            "";
+      }
+      if (!description) {
+         description = updatedCharge.metadata?.productName || updatedCharge.metadata?.description || "Payment";
+      }
+
+      const refunds =
+         updatedCharge.refunds?.data?.map((r: Stripe.Refund) => ({
+            id: r.id,
+            amount: r.amount,
+            status: r.status,
+            created: r.created,
+         })) || [];
+      
+      const updatedTransaction: UserTransaction = {
+         id: updatedCharge.id,
+         amount: updatedCharge.amount,
+         amountRefunded: updatedCharge.amount_refunded,
+         refunded: updatedCharge.refunded,
+         created: updatedCharge.created,
+         description,
+         paymentIntentId:
+            typeof updatedCharge.payment_intent === "string"
+               ? updatedCharge.payment_intent
+               : updatedCharge.payment_intent?.id || null,
+         refunds,
+         currency: updatedCharge.currency,
+
+      }
+
+      return {
+         message: refund.status === "succeeded" ? "Refund issued successfully." : "Refund pending.",
+         status: refund.status === "succeeded" ? "succeeded" : "pending",
+         refund: {
+            id: refund.id,
+            amount: refund.amount,
+            status: refund.status,
+            created: refund.created,
+         },
+         updatedTransaction,
+      };
+
+
+   } catch (error: any) {
+      return {
+         errors: {
+            _form: [error.message || "Failed to create refund."],
+         },
+         status: "failed",
+      };
+   }
 }

--- a/app/(authenticated)/users/actions.ts
+++ b/app/(authenticated)/users/actions.ts
@@ -368,16 +368,29 @@ export async function createTransactionRefund(
       chargeId: formData.get("chargeId"),
       amountCents,
       idempotencyKey: formData.get("idempotencyKey"),
+      customerId: formData.get("customerId")
    });
 
    if (!parsed.success) {
       return {errors : parsed.error.flatten().fieldErrors};
    }
-   const {chargeId, amountCents: refundAmount, idempotencyKey} = parsed.data;
+   const {chargeId, amountCents: refundAmount, idempotencyKey, customerId} = parsed.data;
 
 
    try {
       const charge = await stripe.charges.retrieve(chargeId);
+      const chargeCustomerId =
+         typeof charge.customer === "string"
+            ? charge.customer
+            : charge.customer?.id ?? null;
+
+      if (chargeCustomerId !== customerId){
+         return {
+            errors: { _form: ["Charge does not belong to this customer."] },
+            status: "failed",
+         };
+      }
+
       const remainingRefundable  = charge.amount - charge.amount_refunded;
 
       if (remainingRefundable <= 0) {

--- a/app/(authenticated)/users/actions.ts
+++ b/app/(authenticated)/users/actions.ts
@@ -380,6 +380,26 @@ export async function createTransactionRefund(
 
 
    try {
+      const charge = await stripe.charges.retrieve(chargeId);
+      const remainingRefundable  = charge.amount - charge.amount_refunded;
+
+      if (remainingRefundable <= 0) {
+         return {
+            errors: { _form: ["This charge is already fully refunded."] },
+            status: "failed",
+         };
+      }
+
+      if (refundAmount !== undefined && refundAmount > remainingRefundable) {
+         return {
+            errors: {
+               _form: ["Refund amount exceeds the remaining refundable balance."],
+            },
+            status: "failed",
+         };
+      }
+
+
       const refundParams: Stripe.RefundCreateParams = {
          charge:chargeId,
       };
@@ -390,6 +410,16 @@ export async function createTransactionRefund(
 
       const refund = await stripe.refunds.create(refundParams, { idempotencyKey
       })
+
+      if (refund.status === "failed" || refund.status === "canceled") {
+         const reason = 
+            refund.failure_reason ??
+            refund.status;
+         return {
+            errors : { _form : [`Refund ${reason}.`]},
+            status: "failed",
+         }
+      }
 
       const updatedCharge = await stripe.charges.retrieve(chargeId, {
          expand: [ "refunds", "payment_intent"],
@@ -432,7 +462,10 @@ export async function createTransactionRefund(
       }
 
       return {
-         message: refund.status === "succeeded" ? "Refund issued successfully." : "Refund pending.",
+         message:
+            refund.status === "succeeded"
+               ? "Refund issued successfully."
+               : "Refund pending.",
          status: refund.status === "succeeded" ? "succeeded" : "pending",
          refund: {
             id: refund.id,

--- a/app/(authenticated)/users/actions.ts
+++ b/app/(authenticated)/users/actions.ts
@@ -323,8 +323,8 @@ export async function getUserTransactions(
          description = charge.metadata?.productName || charge.metadata?.description || "Payment";
       }
 
-      const refunds = 
-         (charge as any).refunds?.data?.map((r:Stripe.Refund)=> ({
+      const refunds =
+         charge.refunds?.data?.map((r) => ({
             id: r.id,
             amount: r.amount,
             status: r.status,
@@ -477,12 +477,12 @@ export async function createTransactionRefund(
       };
 
 
-   } catch (error: any) {
+   } catch (error) {
       return {
          errors: {
-            _form: [error.message || "Failed to create refund."],
+            _form: [error instanceof Error ? error.message : "Failed to create refund."],
          },
-         status: "failed",
+        status: "failed",
       };
    }
 }

--- a/app/(authenticated)/users/actions.ts
+++ b/app/(authenticated)/users/actions.ts
@@ -288,7 +288,6 @@ export async function getUserTransactions(
       customerId: string;
       limit?:number;
       startingAfter?: string;
-      endingBefore?:string;
    }
 ): Promise<PaginatedTransactions> {
    await requireAdmin();
@@ -301,10 +300,8 @@ export async function getUserTransactions(
       expand: ["data.refunds", "data.payment_intent"]
    };
 
-   if(parsed.startingAfter){
+   if (parsed.startingAfter) {
       params.starting_after = parsed.startingAfter;
-   } else if (parsed.endingBefore) {
-      params.ending_before = parsed.endingBefore;
    }
 
    const charges = await stripe.charges.list(params)

--- a/app/(authenticated)/users/schema.ts
+++ b/app/(authenticated)/users/schema.ts
@@ -21,3 +21,16 @@ export const updateUserAdminSchema = z.object({
     email: z.string().email(),
     role: z.enum(Object.values(ROLES) as [string, ...string[]]),
 })
+
+export const getTransactionsSchema = z.object({
+  customerId: z.string().min(1,"Customer ID is required"),
+  limit: z.number().min(1).max(100).optional().default(10),
+  startingAfter: z.string().optional(),
+  endingBefore: z.string().optional(),
+});
+
+export const createRefundSchema = z.object({
+  chargeId: z.string().min(1, "Charge ID is required"),
+  amountCents: z.coerce.number().int().positive().optional(),
+  idempotencyKey: z.string().min(1,"Idempotency key is required")
+})

--- a/app/(authenticated)/users/schema.ts
+++ b/app/(authenticated)/users/schema.ts
@@ -26,7 +26,6 @@ export const getTransactionsSchema = z.object({
   customerId: z.string().min(1,"Customer ID is required"),
   limit: z.number().min(1).max(100).optional().default(10),
   startingAfter: z.string().optional(),
-  endingBefore: z.string().optional(),
 });
 
 export const createRefundSchema = z.object({

--- a/app/(authenticated)/users/schema.ts
+++ b/app/(authenticated)/users/schema.ts
@@ -31,5 +31,6 @@ export const getTransactionsSchema = z.object({
 export const createRefundSchema = z.object({
   chargeId: z.string().min(1, "Charge ID is required"),
   amountCents: z.coerce.number().int().positive().optional(),
-  idempotencyKey: z.string().min(1,"Idempotency key is required")
+  idempotencyKey: z.string().min(1,"Idempotency key is required"),
+  customerId: z.string().min(1, "Customer ID is required")
 })


### PR DESCRIPTION
Closes #89

### Overview

Admins can view a customer’s Stripe charge history and issue full or partial refunds directly from the Users table, without leaving the app.

Backend (actions.ts, schema.ts)

getUserTransactions — lists charges for a Stripe customer with cursor pagination (starting_after / ending_before), expanded refunds and payment intents, and mapped descriptions from charge / PI / metadata.
createTransactionRefund — creates refunds via Stripe with idempotency keys, admin auth, server-side refundable balance checks, and returns the updated charge for the UI.
Zod schemas for list params and refund payloads.
UI (user-transactions-modals.tsx, user-actions-cell.tsx)

Receipt icon on each user row (when they have a stripeCustomerId) opens a transactions modal.
Paginated table: date, description, amount, refund status.
Row click opens a refund dialog with refund history, partial amount input, and confirm-before-submit for full/partial refunds.
Toast feedback for success, pending, and error states.


### Testing

Unit tests (actions.test.ts)

getUserTransactions: admin guard, charge mapping from Stripe list response.
createTransactionRefund: unauthorized, fully refunded charge, over-cap partial, successful full refund with updated transaction.

### Screenshots / Screencasts

<img width="1130" height="499" alt="image" src="https://github.com/user-attachments/assets/6b9fcf9b-b4d1-48c3-a0d6-388899b283cf" />
<img width="751" height="492" alt="image" src="https://github.com/user-attachments/assets/d0f6abfa-c0ef-41ab-a736-59c7fee3d4d6" />
<img width="483" height="601" alt="image" src="https://github.com/user-attachments/assets/23f202de-66d7-4ac1-afbe-7e993a4dfb3f" />
<img width="503" height="298" alt="image" src="https://github.com/user-attachments/assets/d3aa3cfc-030f-41a4-bed5-0e53d2f016e5" />
<img width="514" height="594" alt="image" src="https://github.com/user-attachments/assets/15ede14c-31a6-4e12-a149-e12481a422a3" />
<img width="753" height="693" alt="image" src="https://github.com/user-attachments/assets/483d4e06-b540-4e48-a3ce-7a5d1ca50832" />

### Checklist
- [x] Code is neat, readable, and works
- [x] Code is commented where appropriate and well-documented
- [x] Commit messages follow our [guidelines](https://www.conventionalcommits.org)
- [x] Issue number is linked
- [x] Branch is linked
- [x] Reviewers are assigned (one of your tech leads)



### Notes


