### PR TITLE
refactor(users): remove status column from users table component

### DIFF
--- a/app/(authenticated)/users/_components/users-columns.tsx
+++ b/app/(authenticated)/users/_components/users-columns.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { ColumnDef } from "@tanstack/react-table";
-import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarFallback} from "@/components/ui/avatar";
 import { profileRoleLabel, type UserRow } from "../profile-role-label";
 import { UserActionsCell } from "./user-actions-cell";
@@ -50,24 +49,6 @@ export function getUsersColumns(
             </span>
          </span>
       ),
-   },
-   {
-      id: "status",
-      header: "Status",
-      meta: { colWidth: "14%" },
-      cell: ({ row }) => {
-         const active = row.original.isActive;
-         return (
-            <Badge variant={active ? "default" : "secondary"} className="gap-1.5">
-               <span
-                  className={`h-2 w-2 rounded-full ${
-                     active ? "bg-green-500" : "bg-muted-foreground/50"
-                  }`}
-               />
-               {active ? "Active" : "Inactive"}
-            </Badge>
-         );
-      },
    },
    {
       id: "lastLoginAt",


### PR DESCRIPTION
Closes #98 

### Overview

Remove the **Status** column from the admin Users table (`/users`). The column showed Active/Inactive badges derived from subscription status (`isActive` in queries), not a database field.

**Changes:**
- Removed the Status column definition from `users-columns.tsx`
- Removed the unused `Badge` import

Active/Inactive **filter tabs** are unchanged — they still use `isActive` from `queries.ts`. Only the table column was removed.

### Testing

**Manual:**
- Logged in as admin and opened `/users`
- Confirmed the table shows: User Profile, Role, Last Login, Actions (no Status column)
- Confirmed Active / Inactive / All Users tabs still filter correctly
- Confirmed search, role filter, and sort still work

**Automated:**
- No new tests needed — UI-only column removal with no logic changes

### Screenshots / Screencasts

{Attach screenshot of the Users table without the Status column — required by acceptance criteria}

### Checklist
- [x] Code is neat, readable, and works
- [x] Code is commented where appropriate and well-documented
- [x] Commit messages follow our [guidelines](https://www.conventionalcommits.org)
- [x] Issue number is linked
- [ ] Branch is linked
- [ ] Reviewers are assigned (one of your tech leads)

Tip: You can make the issue and then check them after the fact or replace `[ ]` with `[x]` to check it!

### Notes

Small, scoped UI change — no schema, API, or query changes. The Status column was redundant with the existing Active/Inactive tabs on the same page.