### PR TITLE
Feature/88:  rename coach to coordinator, multi-coordinator programs, and coordinator dashboard

### DIFF
--- a/__tests__/services-actions.test.ts
+++ b/__tests__/services-actions.test.ts
@@ -7,7 +7,8 @@ import {
 } from "@/app/(authenticated)/services/actions";
 
 // db mock
-const insertValues = jest.fn().mockResolvedValue(undefined);
+const insertReturning = jest.fn();
+const insertValues = jest.fn(() => ({ returning: insertReturning }));
 const insert = jest.fn(() => ({ values: insertValues })) as jest.Mock;
 
 const selectLimit = jest.fn();
@@ -19,11 +20,15 @@ const updateWhere = jest.fn().mockResolvedValue(undefined);
 const updateSet = jest.fn(() => ({ where: updateWhere }));
 const update = jest.fn(() => ({ set: updateSet })) as jest.Mock;
 
+const deleteWhere = jest.fn().mockResolvedValue(undefined);
+const del = jest.fn(() => ({ where: deleteWhere })) as jest.Mock;
+
 jest.mock("@/lib/db", () => ({
    db: {
       insert: (...args: unknown[]) => insert(...args),
       select: (...args: unknown[]) => select(...args),
       update: (...args: unknown[]) => update(...args),
+      delete: (...args: unknown[]) => del(...args),
    },
 }));
 
@@ -44,13 +49,16 @@ jest.mock("@/lib/stripe", () => ({
 
 // auth + cache mocks
 const requireAdmin = jest.fn();
+const getUserRole = jest.fn();
 jest.mock("@/lib/auth/require-admin", () => ({
    requireAdmin: (...args: unknown[]) => requireAdmin(...args),
+   getUserRole: (...args: unknown[]) => getUserRole(...args),
 }));
 
 jest.mock("next/cache", () => ({
    revalidatePath: jest.fn(),
    updateTag: jest.fn(),
+   cacheTag: jest.fn(),
 }));
 
 const COORDINATOR_A = "11111111-1111-1111-1111-111111111111";
@@ -66,6 +74,7 @@ function fd(obj: Record<string, string>): FormData {
 beforeEach(() => {
    jest.clearAllMocks();
    requireAdmin.mockResolvedValue(undefined);
+   insertReturning.mockResolvedValue([{ id: SERVICE_ID }]);
    createProduct.mockResolvedValue({ productId: "prod_1" });
    createPrice.mockResolvedValue(undefined);
    updateProduct.mockResolvedValue(undefined);
@@ -130,6 +139,31 @@ describe("createService", () => {
          expect.objectContaining({ type: "programs", coordinatorId: null }),
       );
    });
+
+   it("assigns multiple coordinators to a program", async () => {
+      const result = await createService(
+         null,
+         fd({
+            title: "Summer Program",
+            description: "Group program",
+            type: "programs",
+            duration_minutes: "60",
+            price_cad: "100.00",
+            start_date: "2026-01-01",
+            end_date: "2026-02-01",
+            slots: JSON.stringify([{ dayOfWeek: 1, time: "10:00" }]),
+            coordinator_ids: JSON.stringify([COORDINATOR_A, COORDINATOR_B]),
+         }),
+      );
+
+      expect(result).toEqual({ message: "Service created." });
+      expect(insertValues).toHaveBeenCalledWith(
+         expect.arrayContaining([
+            { serviceId: SERVICE_ID, coordinatorId: COORDINATOR_A },
+            { serviceId: SERVICE_ID, coordinatorId: COORDINATOR_B },
+         ]),
+      );
+   });
 });
 
 describe("updateService", () => {
@@ -152,6 +186,31 @@ describe("updateService", () => {
       expect(updateSet).toHaveBeenCalledWith(
          expect.objectContaining({ coordinatorId: COORDINATOR_B }),
       );
+   });
+
+   it("replaces program coordinators on update", async () => {
+      selectLimit.mockResolvedValue([
+         {
+            id: SERVICE_ID,
+            type: "programs",
+            status: "active",
+            stripeProductId: "prod_1",
+         },
+      ]);
+
+      const result = await updateService(
+         null,
+         fd({
+            service_id: SERVICE_ID,
+            coordinator_ids: JSON.stringify([COORDINATOR_A]),
+         }),
+      );
+
+      expect(result).toEqual({ message: "Service updated." });
+      expect(del).toHaveBeenCalled();
+      expect(insertValues).toHaveBeenCalledWith([
+         { serviceId: SERVICE_ID, coordinatorId: COORDINATOR_A },
+      ]);
    });
 
    it("does not recreate the Stripe price when the amount is unchanged", async () => {

--- a/app/(authenticated)/finance/page.tsx
+++ b/app/(authenticated)/finance/page.tsx
@@ -1,4 +1,13 @@
-export default function FinancePage() {
+import { redirect } from "next/navigation";
+import { requireAdmin } from "@/lib/auth/require-admin";
+
+export default async function FinancePage() {
+   try {
+      await requireAdmin();
+   } catch {
+      redirect("/");
+   }
+
    return (
       <main className="flex min-h-screen flex-col p-8">
          <h1 className="text-3xl font-bold">Finance</h1>

--- a/app/(authenticated)/layout.tsx
+++ b/app/(authenticated)/layout.tsx
@@ -5,6 +5,8 @@ import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "@/components/ui/sonner";
 import { AppSidebar } from "@/components/app-sidebar";
+import { getUserRole } from "@/lib/auth/require-admin";
+import { ROLES, type Role } from "@/lib/roles";
 
 async function AuthGate({ children }: { children: React.ReactNode }) {
    const supabase = await createClient();
@@ -19,6 +21,11 @@ async function AuthGate({ children }: { children: React.ReactNode }) {
    return <>{children}</>;
 }
 
+async function Nav() {
+   const role = (await getUserRole()) ?? ROLES.USER;
+   return <AppSidebar role={role as Role} />;
+}
+
 export default function AuthenticatedLayout({
    children,
 }: {
@@ -27,7 +34,9 @@ export default function AuthenticatedLayout({
    return (
       <TooltipProvider>
          <SidebarProvider>
-            <AppSidebar />
+            <Suspense fallback={<AppSidebar role={ROLES.USER} />}>
+               <Nav />
+            </Suspense>
             <SidebarInset>
                <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden p-4">
                   <Suspense fallback={null}>

--- a/app/(authenticated)/layout.tsx
+++ b/app/(authenticated)/layout.tsx
@@ -34,7 +34,7 @@ export default function AuthenticatedLayout({
    return (
       <TooltipProvider>
          <SidebarProvider>
-            <Suspense fallback={<AppSidebar role={ROLES.USER} />}>
+            <Suspense fallback={null}>
                <Nav />
             </Suspense>
             <SidebarInset>

--- a/app/(authenticated)/memberships/page.tsx
+++ b/app/(authenticated)/memberships/page.tsx
@@ -1,7 +1,16 @@
-export default function MembershipsPage() {
-  return (
-    <main className="flex min-h-screen flex-col p-8">
-      <h1 className="text-3xl font-bold">Memberships</h1>
-    </main>
-  )
+import { redirect } from "next/navigation";
+import { requireAdmin } from "@/lib/auth/require-admin";
+
+export default async function MembershipsPage() {
+   try {
+      await requireAdmin();
+   } catch {
+      redirect("/");
+   }
+
+   return (
+      <main className="flex min-h-screen flex-col p-8">
+         <h1 className="text-3xl font-bold">Memberships</h1>
+      </main>
+   );
 }

--- a/app/(authenticated)/page.tsx
+++ b/app/(authenticated)/page.tsx
@@ -1,10 +1,6 @@
 import { Suspense } from "react";
-import { redirect } from "next/navigation";
 import { createClient } from "@/utils/supabase/server";
-import { getUserRole } from "@/lib/auth/require-admin";
-import { ROLES } from "@/lib/roles";
 import { signout } from "@/app/login/actions";
-import { getSubscriptionDetails } from "@/lib/stripe";
 import {
    Card,
    CardContent,
@@ -13,10 +9,6 @@ import {
    CardTitle,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { CheckoutButton } from "@/components/subscribe-button";
-
-const SUBSCRIPTION_PRICE_ID = process.env.STRIPE_PRICE_ID!;
-const PRODUCT_PRICE_ID = process.env.STRIPE_PRODUCT_PRICE_ID!;
 
 export default function Page() {
    return (
@@ -34,14 +26,6 @@ async function HomeContent() {
 
    if (!user) return null;
 
-   // Coordinators have no overview tab — send them to their scoped dashboard.
-   if ((await getUserRole()) === ROLES.COORDINATOR) {
-      redirect("/services");
-   }
-
-   const [subscription] = await Promise.all([getSubscriptionDetails(user.id)]);
-   const ownsProduct = false;
-
    return (
       <main className="min-h-screen p-4 w-full">
          <div className="flex flex-row gap-4 w-full">
@@ -57,94 +41,6 @@ async function HomeContent() {
                         Sign out
                      </Button>
                   </form>
-               </CardContent>
-            </Card>
-
-            <Card className="flex-1">
-               <CardHeader>
-                  <CardTitle>Subscription</CardTitle>
-                  <CardDescription>
-                     {subscription
-                        ? "Your current plan"
-                        : "Subscribe to unlock premium features"}
-                  </CardDescription>
-               </CardHeader>
-               <CardContent>
-                  {subscription ? (
-                     <div className="space-y-3">
-                        <div className="flex items-center justify-between">
-                           <span className="text-sm text-gray-500">Plan</span>
-                           <span className="text-sm font-medium">
-                              {subscription.planName}
-                           </span>
-                        </div>
-                        <div className="flex items-center justify-between">
-                           <span className="text-sm text-gray-500">Price</span>
-                           <span className="text-sm font-medium">
-                              ${(subscription.priceAmount / 100).toFixed(2)}/
-                              {subscription.priceInterval}
-                           </span>
-                        </div>
-                        <div className="flex items-center justify-between">
-                           <span className="text-sm text-gray-500">Status</span>
-                           <div className="flex items-center gap-1.5">
-                              <span className="h-2 w-2 rounded-full bg-green-500" />
-                              <span className="text-sm font-medium text-green-700">
-                                 Active
-                              </span>
-                           </div>
-                        </div>
-                        {subscription.paymentMethodBrand && (
-                           <div className="flex items-center justify-between">
-                              <span className="text-sm text-gray-500">
-                                 Payment
-                              </span>
-                              <span className="text-sm font-medium capitalize">
-                                 {subscription.paymentMethodBrand} ****
-                                 {subscription.paymentMethodLast4}
-                              </span>
-                           </div>
-                        )}
-                        {subscription.cancelAtPeriodEnd && (
-                           <p className="text-sm text-amber-600">
-                              Cancels at end of billing period
-                           </p>
-                        )}
-                     </div>
-                  ) : (
-                     <CheckoutButton
-                        priceId={SUBSCRIPTION_PRICE_ID}
-                        mode="subscription"
-                        label="Subscribe"
-                     />
-                  )}
-               </CardContent>
-            </Card>
-
-            <Card className="flex-1">
-               <CardHeader>
-                  <CardTitle>Product</CardTitle>
-                  <CardDescription>
-                     {ownsProduct
-                        ? "You own this product"
-                        : "One-time purchase"}
-                  </CardDescription>
-               </CardHeader>
-               <CardContent>
-                  {ownsProduct ? (
-                     <div className="flex items-center gap-2">
-                        <span className="h-2 w-2 rounded-full bg-green-500" />
-                        <span className="text-sm font-medium text-green-700">
-                           Purchased
-                        </span>
-                     </div>
-                  ) : (
-                     <CheckoutButton
-                        priceId={PRODUCT_PRICE_ID}
-                        mode="payment"
-                        label="Buy Now"
-                     />
-                  )}
                </CardContent>
             </Card>
          </div>

--- a/app/(authenticated)/page.tsx
+++ b/app/(authenticated)/page.tsx
@@ -1,6 +1,9 @@
 import { Suspense } from "react";
 import { createClient } from "@/utils/supabase/server";
 import { signout } from "@/app/login/actions";
+import { getUserRole } from "@/lib/auth/require-admin";
+import { ROLES } from "@/lib/roles";
+import { getSubscriptionDetails } from "@/lib/stripe";
 import {
    Card,
    CardContent,
@@ -9,12 +12,35 @@ import {
    CardTitle,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { CheckoutButton } from "@/components/subscribe-button";
+
+const SUBSCRIPTION_PRICE_ID = process.env.STRIPE_PRICE_ID!;
+const PRODUCT_PRICE_ID = process.env.STRIPE_PRODUCT_PRICE_ID!;
 
 export default function Page() {
    return (
       <Suspense>
          <HomeContent />
       </Suspense>
+   );
+}
+
+function WelcomeCard({ email }: { email: string }) {
+   return (
+      <Card className="flex-1">
+         <CardHeader>
+            <CardTitle className="text-2xl">Welcome</CardTitle>
+            <CardDescription>You are signed in as</CardDescription>
+         </CardHeader>
+         <CardContent className="space-y-4">
+            <p className="text-sm font-medium">{email}</p>
+            <form>
+               <Button formAction={signout} variant="outline">
+                  Sign out
+               </Button>
+            </form>
+         </CardContent>
+      </Card>
    );
 }
 
@@ -26,21 +52,112 @@ async function HomeContent() {
 
    if (!user) return null;
 
+   const role = await getUserRole();
+
+   // Coordinators get a minimal overview — just the welcome / sign-out card.
+   if (role === ROLES.COORDINATOR) {
+      return (
+         <main className="p-4">
+            <div className="max-w-sm">
+               <WelcomeCard email={user.email!} />
+            </div>
+         </main>
+      );
+   }
+
+   const [subscription] = await Promise.all([getSubscriptionDetails(user.id)]);
+   const ownsProduct = false;
+
    return (
       <main className="min-h-screen p-4 w-full">
          <div className="flex flex-row gap-4 w-full">
+            <WelcomeCard email={user.email!} />
+
             <Card className="flex-1">
                <CardHeader>
-                  <CardTitle className="text-2xl">Welcome</CardTitle>
-                  <CardDescription>You are signed in as</CardDescription>
+                  <CardTitle>Subscription</CardTitle>
+                  <CardDescription>
+                     {subscription
+                        ? "Your current plan"
+                        : "Subscribe to unlock premium features"}
+                  </CardDescription>
                </CardHeader>
-               <CardContent className="space-y-4">
-                  <p className="text-sm font-medium">{user.email}</p>
-                  <form>
-                     <Button formAction={signout} variant="outline">
-                        Sign out
-                     </Button>
-                  </form>
+               <CardContent>
+                  {subscription ? (
+                     <div className="space-y-3">
+                        <div className="flex items-center justify-between">
+                           <span className="text-sm text-gray-500">Plan</span>
+                           <span className="text-sm font-medium">
+                              {subscription.planName}
+                           </span>
+                        </div>
+                        <div className="flex items-center justify-between">
+                           <span className="text-sm text-gray-500">Price</span>
+                           <span className="text-sm font-medium">
+                              ${(subscription.priceAmount / 100).toFixed(2)}/
+                              {subscription.priceInterval}
+                           </span>
+                        </div>
+                        <div className="flex items-center justify-between">
+                           <span className="text-sm text-gray-500">Status</span>
+                           <div className="flex items-center gap-1.5">
+                              <span className="h-2 w-2 rounded-full bg-green-500" />
+                              <span className="text-sm font-medium text-green-700">
+                                 Active
+                              </span>
+                           </div>
+                        </div>
+                        {subscription.paymentMethodBrand && (
+                           <div className="flex items-center justify-between">
+                              <span className="text-sm text-gray-500">
+                                 Payment
+                              </span>
+                              <span className="text-sm font-medium capitalize">
+                                 {subscription.paymentMethodBrand} ****
+                                 {subscription.paymentMethodLast4}
+                              </span>
+                           </div>
+                        )}
+                        {subscription.cancelAtPeriodEnd && (
+                           <p className="text-sm text-amber-600">
+                              Cancels at end of billing period
+                           </p>
+                        )}
+                     </div>
+                  ) : (
+                     <CheckoutButton
+                        priceId={SUBSCRIPTION_PRICE_ID}
+                        mode="subscription"
+                        label="Subscribe"
+                     />
+                  )}
+               </CardContent>
+            </Card>
+
+            <Card className="flex-1">
+               <CardHeader>
+                  <CardTitle>Product</CardTitle>
+                  <CardDescription>
+                     {ownsProduct
+                        ? "You own this product"
+                        : "One-time purchase"}
+                  </CardDescription>
+               </CardHeader>
+               <CardContent>
+                  {ownsProduct ? (
+                     <div className="flex items-center gap-2">
+                        <span className="h-2 w-2 rounded-full bg-green-500" />
+                        <span className="text-sm font-medium text-green-700">
+                           Purchased
+                        </span>
+                     </div>
+                  ) : (
+                     <CheckoutButton
+                        priceId={PRODUCT_PRICE_ID}
+                        mode="payment"
+                        label="Buy Now"
+                     />
+                  )}
                </CardContent>
             </Card>
          </div>

--- a/app/(authenticated)/page.tsx
+++ b/app/(authenticated)/page.tsx
@@ -1,5 +1,8 @@
 import { Suspense } from "react";
+import { redirect } from "next/navigation";
 import { createClient } from "@/utils/supabase/server";
+import { getUserRole } from "@/lib/auth/require-admin";
+import { ROLES } from "@/lib/roles";
 import { signout } from "@/app/login/actions";
 import { getSubscriptionDetails } from "@/lib/stripe";
 import {
@@ -30,6 +33,11 @@ async function HomeContent() {
    } = await supabase.auth.getUser();
 
    if (!user) return null;
+
+   // Coordinators have no overview tab — send them to their scoped dashboard.
+   if ((await getUserRole()) === ROLES.COORDINATOR) {
+      redirect("/services");
+   }
 
    const [subscription] = await Promise.all([getSubscriptionDetails(user.id)]);
    const ownsProduct = false;

--- a/app/(authenticated)/scheduled-lessons/page.tsx
+++ b/app/(authenticated)/scheduled-lessons/page.tsx
@@ -1,0 +1,33 @@
+import { redirect } from "next/navigation";
+
+import { createClient } from "@/utils/supabase/server";
+import { getUserRole } from "@/lib/auth/require-admin";
+import { ROLES } from "@/lib/roles";
+
+import { listUpcomingLessonsForCoordinator } from "./queries";
+import { ScheduledLessonsTable } from "./scheduled-lessons-table";
+
+export default async function ScheduledLessonsPage() {
+   const role = await getUserRole();
+   if (role !== ROLES.ADMIN && role !== ROLES.COORDINATOR) {
+      redirect("/");
+   }
+
+   const supabase = await createClient();
+   const {
+      data: { user },
+   } = await supabase.auth.getUser();
+   if (!user) redirect("/login");
+
+   const lessons = await listUpcomingLessonsForCoordinator(user.id);
+
+   return (
+      <main className="flex min-h-screen flex-col gap-6 p-8">
+         <h1 className="text-3xl font-bold">Scheduled lessons</h1>
+         <p className="text-sm text-muted-foreground">
+            Upcoming private lessons you coordinate.
+         </p>
+         <ScheduledLessonsTable lessons={lessons} />
+      </main>
+   );
+}

--- a/app/(authenticated)/scheduled-lessons/queries.ts
+++ b/app/(authenticated)/scheduled-lessons/queries.ts
@@ -1,0 +1,72 @@
+import { and, asc, eq, inArray } from "drizzle-orm";
+
+import { db } from "@/lib/db";
+import {
+   privateLessonSessions,
+   profiles,
+   services,
+} from "@/lib/db/schema";
+import { getStripeServiceData } from "@/lib/stripe";
+import type { TimeSlot } from "@/lib/scheduling/time-slot";
+
+const UUID_RE =
+   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export type ScheduledLessonView = {
+   id: string;
+   serviceTitle: string | null;
+   clientName: string;
+   scheduledAt: Date | null;
+   meetingUrl: string | null;
+   selectedTimeSlots: TimeSlot[];
+   status: string;
+};
+
+/**
+ * Upcoming private-lesson sessions a coordinator is responsible for: sessions
+ * that are still pending or confirmed (not cancelled/completed), ordered by
+ * scheduled time. Includes the service title and the client's name.
+ */
+export async function listUpcomingLessonsForCoordinator(
+   coordinatorId: string,
+): Promise<ScheduledLessonView[]> {
+   if (!UUID_RE.test(coordinatorId)) return [];
+
+   const rows = await db
+      .select({
+         id: privateLessonSessions.id,
+         scheduledAt: privateLessonSessions.scheduledAt,
+         meetingUrl: privateLessonSessions.meetingUrl,
+         selectedTimeSlots: privateLessonSessions.selectedTimeSlots,
+         status: privateLessonSessions.status,
+         stripeProductId: services.stripeProductId,
+         clientFirstName: profiles.firstName,
+         clientLastName: profiles.lastName,
+      })
+      .from(privateLessonSessions)
+      .innerJoin(services, eq(services.id, privateLessonSessions.serviceId))
+      .innerJoin(profiles, eq(profiles.id, privateLessonSessions.userId))
+      .where(
+         and(
+            eq(privateLessonSessions.coordinatorId, coordinatorId),
+            inArray(privateLessonSessions.status, ["pending", "confirmed"]),
+         ),
+      )
+      .orderBy(asc(privateLessonSessions.scheduledAt));
+
+   return Promise.all(
+      rows.map(async (r) => {
+         const stripeData = await getStripeServiceData(r.stripeProductId);
+         return {
+            id: r.id,
+            serviceTitle: stripeData?.title ?? null,
+            clientName: `${r.clientFirstName} ${r.clientLastName}`.trim(),
+            scheduledAt: r.scheduledAt,
+            meetingUrl: r.meetingUrl,
+            selectedTimeSlots:
+               (r.selectedTimeSlots as TimeSlot[] | null) ?? [],
+            status: r.status,
+         };
+      }),
+   );
+}

--- a/app/(authenticated)/scheduled-lessons/scheduled-lessons-table.tsx
+++ b/app/(authenticated)/scheduled-lessons/scheduled-lessons-table.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import * as React from "react";
+import { ColumnDef } from "@tanstack/react-table";
+import { format } from "date-fns";
+
+import { DataTable } from "@/components/data-table";
+import type { ScheduledLessonView } from "./queries";
+
+function formatSlot(iso: string): string {
+   const d = new Date(iso);
+   return Number.isNaN(d.getTime()) ? iso : format(d, "LLL d, h:mm a");
+}
+
+export function ScheduledLessonsTable({
+   lessons,
+}: {
+   lessons: ScheduledLessonView[];
+}) {
+   const columns = React.useMemo<ColumnDef<ScheduledLessonView>[]>(
+      () => [
+         {
+            accessorKey: "serviceTitle",
+            header: "Service",
+            cell: ({ row }) => (
+               <span className="font-medium">
+                  {row.original.serviceTitle ?? "—"}
+               </span>
+            ),
+         },
+         {
+            accessorKey: "clientName",
+            header: "Client",
+            cell: ({ row }) => row.original.clientName || "—",
+         },
+         {
+            id: "scheduledAt",
+            header: "Scheduled at",
+            cell: ({ row }) => {
+               const s = row.original.scheduledAt;
+               return s ? format(new Date(s), "LLL d, yyyy h:mm a") : (
+                  <span className="text-muted-foreground">Not scheduled</span>
+               );
+            },
+         },
+         {
+            id: "meetingUrl",
+            header: "Meeting",
+            cell: ({ row }) => {
+               const url = row.original.meetingUrl;
+               return url ? (
+                  <a
+                     href={url}
+                     target="_blank"
+                     rel="noopener noreferrer"
+                     className="text-primary underline underline-offset-2"
+                  >
+                     Join
+                  </a>
+               ) : (
+                  <span className="text-muted-foreground">—</span>
+               );
+            },
+         },
+         {
+            id: "selectedTimeSlots",
+            header: "Requested slots",
+            cell: ({ row }) => {
+               const slots = row.original.selectedTimeSlots;
+               if (slots.length === 0)
+                  return <span className="text-muted-foreground">—</span>;
+               return (
+                  <ul className="flex flex-col gap-0.5 text-xs">
+                     {slots.map((slot, i) => (
+                        <li key={i}>
+                           {formatSlot(slot.start)} – {formatSlot(slot.end)}
+                        </li>
+                     ))}
+                  </ul>
+               );
+            },
+         },
+      ],
+      [],
+   );
+
+   return (
+      <DataTable
+         columns={columns}
+         data={lessons}
+         emptyMessage="No upcoming scheduled lessons."
+         rowLabel={(n) => `${n} lesson${n === 1 ? "" : "s"}`}
+      />
+   );
+}

--- a/app/(authenticated)/services/actions.ts
+++ b/app/(authenticated)/services/actions.ts
@@ -4,8 +4,22 @@ import { revalidatePath, updateTag } from "next/cache";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "@/lib/db";
-import { services, type ProgramSlot as DbProgramSlot } from "@/lib/db/schema";
-import { requireAdmin } from "@/lib/auth/require-admin";
+import {
+   programCoordinators,
+   services,
+   type ProgramSlot as DbProgramSlot,
+} from "@/lib/db/schema";
+import {
+   getUserRole,
+   requireAdmin,
+} from "@/lib/auth/require-admin";
+import { ROLES } from "@/lib/roles";
+import { createClient } from "@/utils/supabase/server";
+import {
+   isServiceCoordinator,
+   listServiceRegistrations,
+   type ServiceRegistration,
+} from "@/app/(authenticated)/services/queries";
 import { cadStringToCents } from "@/lib/money";
 import {
    createPrice,
@@ -124,6 +138,56 @@ function parseProgramSchedule(
    };
 }
 
+/**
+ * Parse the optional `coordinator_ids` field for programs: a JSON array of
+ * coordinator UUIDs. Programs may have zero or more coordinators, so an empty
+ * or missing value is valid and yields an empty list.
+ */
+function parseCoordinatorIds(formData: FormData): ParseResult<string[]> {
+   const raw = field(formData, "coordinator_ids");
+   if (!raw) return { ok: true, value: [] };
+
+   let parsed: unknown;
+   try {
+      parsed = JSON.parse(raw);
+   } catch {
+      return {
+         ok: false,
+         errors: { coordinator_ids: ["Invalid coordinator selection"] },
+      };
+   }
+
+   const result = z.array(z.string().uuid()).safeParse(parsed);
+   if (!result.success) {
+      return {
+         ok: false,
+         errors: { coordinator_ids: ["Invalid coordinator selection"] },
+      };
+   }
+   // De-duplicate so the unique index never rejects a double-selection.
+   return { ok: true, value: [...new Set(result.data)] };
+}
+
+/**
+ * Replace the program-coordinator rows for a service with the given set.
+ */
+async function setProgramCoordinators(
+   serviceId: string,
+   coordinatorIds: string[],
+): Promise<void> {
+   await db
+      .delete(programCoordinators)
+      .where(eq(programCoordinators.serviceId, serviceId));
+   if (coordinatorIds.length > 0) {
+      await db.insert(programCoordinators).values(
+         coordinatorIds.map((coordinatorId) => ({
+            serviceId,
+            coordinatorId,
+         })),
+      );
+   }
+}
+
 function parseCoordinatorId(formData: FormData): ParseResult<string> {
    const raw = field(formData, "coordinator_id");
    if (!raw)
@@ -179,6 +243,7 @@ export async function createService(
    const typeRaw = formData.get("type")?.toString();
    let scheduledAtValue: ProgramSchedule | null = null;
    let coordinatorIdValue: string | null = null;
+   let coordinatorIdsValue: string[] = [];
    if (typeRaw === "programs") {
       const result = parseProgramSchedule(formData);
       if (!result.ok) {
@@ -186,6 +251,9 @@ export async function createService(
       } else {
          scheduledAtValue = result.value;
       }
+      const coordinators = parseCoordinatorIds(formData);
+      if (!coordinators.ok) Object.assign(errors, coordinators.errors);
+      else coordinatorIdsValue = coordinators.value;
    } else if (typeRaw === "private_lessons") {
       const coordinator = parseCoordinatorId(formData);
       if (!coordinator.ok) Object.assign(errors, coordinator.errors);
@@ -211,16 +279,23 @@ export async function createService(
 
       await createPrice(productId, priceCents);
 
-      await db.insert(services).values({
-         type,
-         startDate: scheduledAtValue?.startDate ?? null,
-         endDate: scheduledAtValue?.endDate ?? null,
-         slots: scheduledAtValue?.slots ?? null,
-         durationMinutes: duration_minutes,
-         stripeProductId: productId,
-         coordinatorId: coordinatorIdValue,
-         status: "active",
-      });
+      const [created] = await db
+         .insert(services)
+         .values({
+            type,
+            startDate: scheduledAtValue?.startDate ?? null,
+            endDate: scheduledAtValue?.endDate ?? null,
+            slots: scheduledAtValue?.slots ?? null,
+            durationMinutes: duration_minutes,
+            stripeProductId: productId,
+            coordinatorId: coordinatorIdValue,
+            status: "active",
+         })
+         .returning({ id: services.id });
+
+      if (type === "programs") {
+         await setProgramCoordinators(created.id, coordinatorIdsValue);
+      }
    } catch (e) {
       if (createdProductId) {
          try {
@@ -324,6 +399,7 @@ export async function updateService(
 
    let scheduledAtValue: ProgramSchedule | undefined;
    let coordinatorIdValue: string | undefined;
+   let coordinatorIdsValue: string[] | undefined;
    if (row.type === "programs" && formData.has("start_date")) {
       const result = parseProgramSchedule(formData);
       if (!result.ok) {
@@ -331,7 +407,13 @@ export async function updateService(
       } else {
          scheduledAtValue = result.value;
       }
-   } else if (
+   }
+   if (row.type === "programs" && formData.has("coordinator_ids")) {
+      const coordinators = parseCoordinatorIds(formData);
+      if (!coordinators.ok) Object.assign(errors, coordinators.errors);
+      else coordinatorIdsValue = coordinators.value;
+   }
+   if (
       row.type === "private_lessons" &&
       formData.has("coordinator_id")
    ) {
@@ -379,6 +461,10 @@ export async function updateService(
             .update(services)
             .set(dbPatch)
             .where(eq(services.id, service_id));
+      }
+
+      if (coordinatorIdsValue !== undefined) {
+         await setProgramCoordinators(service_id, coordinatorIdsValue);
       }
    } catch (e) {
       console.error(e);
@@ -465,4 +551,27 @@ export async function setServiceStatus(
 
    bustServicesCache();
    return { message: "Service status updated." };
+}
+
+/**
+ * On-demand fetch of a service's registrations for the read-only view.
+ * Admins may view any service; coordinators only services they coordinate.
+ */
+export async function fetchServiceRegistrations(
+   serviceId: string,
+): Promise<ServiceRegistration[]> {
+   const role = await getUserRole();
+   if (role === ROLES.ADMIN) {
+      return listServiceRegistrations(serviceId);
+   }
+   if (role === ROLES.COORDINATOR) {
+      const supabase = await createClient();
+      const {
+         data: { user },
+      } = await supabase.auth.getUser();
+      if (user && (await isServiceCoordinator(user.id, serviceId))) {
+         return listServiceRegistrations(serviceId);
+      }
+   }
+   throw new Error("Forbidden");
 }

--- a/app/(authenticated)/services/page.tsx
+++ b/app/(authenticated)/services/page.tsx
@@ -1,16 +1,53 @@
-import { listCoordinators, listServices } from "./queries";
+import { redirect } from "next/navigation";
+
+import { createClient } from "@/utils/supabase/server";
+import { getUserRole } from "@/lib/auth/require-admin";
+import { ROLES } from "@/lib/roles";
+
+import {
+   listCoordinators,
+   listServices,
+   listServicesForCoordinator,
+} from "./queries";
 import { ServicesTable } from "./services-table";
 
 export default async function ServicesPage() {
-   const [services, coordinators] = await Promise.all([
-      listServices(),
-      listCoordinators(),
-   ]);
+   const role = await getUserRole();
 
-   return (
-      <main className="flex min-h-screen flex-col gap-6 p-8">
-         <h1 className="text-3xl font-bold">Services</h1>
-         <ServicesTable services={services} coordinators={coordinators} />
-      </main>
-   );
+   if (role === ROLES.ADMIN) {
+      const [services, coordinators] = await Promise.all([
+         listServices(),
+         listCoordinators(),
+      ]);
+
+      return (
+         <main className="flex min-h-screen flex-col gap-6 p-8">
+            <h1 className="text-3xl font-bold">Services</h1>
+            <ServicesTable services={services} coordinators={coordinators} />
+         </main>
+      );
+   }
+
+   if (role === ROLES.COORDINATOR) {
+      const supabase = await createClient();
+      const {
+         data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) redirect("/login");
+
+      const services = await listServicesForCoordinator(user.id);
+
+      return (
+         <main className="flex min-h-screen flex-col gap-6 p-8">
+            <h1 className="text-3xl font-bold">Services</h1>
+            <p className="text-sm text-muted-foreground">
+               Services you coordinate. View the people registered and their
+               form answers.
+            </p>
+            <ServicesTable services={services} coordinators={[]} readOnly />
+         </main>
+      );
+   }
+
+   redirect("/");
 }

--- a/app/(authenticated)/services/queries.ts
+++ b/app/(authenticated)/services/queries.ts
@@ -1,7 +1,15 @@
 import { cacheTag } from "next/cache";
-import { and, asc, desc, eq, inArray } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, or } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { profiles, services } from "@/lib/db/schema";
+import {
+   children,
+   formQuestionAnswers,
+   formQuestions,
+   profiles,
+   programCoordinators,
+   serviceBookings,
+   services,
+} from "@/lib/db/schema";
 import { getStripeServiceData } from "@/lib/stripe";
 import type { ProgramSchedule } from "@/app/(authenticated)/services/actions";
 
@@ -22,6 +30,8 @@ export type ServiceView = {
    status: ServiceStatus;
    stripeProductId: string;
    coordinatorId: string | null;
+   /** Program coordinators (many-to-many). Empty for private lessons. */
+   coordinatorIds: string[];
    createdAt: Date;
    updatedAt: Date;
    title: string | null;
@@ -43,6 +53,7 @@ function rowToSchedule(
 
 async function buildServiceView(
    row: typeof services.$inferSelect,
+   coordinatorIds: string[] = [],
 ): Promise<ServiceView> {
    const stripeData = await getStripeServiceData(row.stripeProductId);
    return {
@@ -53,6 +64,7 @@ async function buildServiceView(
       status: row.status,
       stripeProductId: row.stripeProductId,
       coordinatorId: row.coordinatorId,
+      coordinatorIds,
       createdAt: row.createdAt,
       updatedAt: row.updatedAt,
       title: stripeData?.title ?? null,
@@ -60,6 +72,32 @@ async function buildServiceView(
       priceCents: stripeData?.priceCents ?? null,
       priceCurrency: stripeData?.priceCurrency ?? null,
    };
+}
+
+/**
+ * Load program-coordinator assignments for the given service ids, grouped by
+ * service id. Returns an empty map when there are no ids.
+ */
+async function loadProgramCoordinators(
+   serviceIds: string[],
+): Promise<Map<string, string[]>> {
+   const map = new Map<string, string[]>();
+   if (serviceIds.length === 0) return map;
+
+   const rows = await db
+      .select({
+         serviceId: programCoordinators.serviceId,
+         coordinatorId: programCoordinators.coordinatorId,
+      })
+      .from(programCoordinators)
+      .where(inArray(programCoordinators.serviceId, serviceIds));
+
+   for (const row of rows) {
+      const existing = map.get(row.serviceId);
+      if (existing) existing.push(row.coordinatorId);
+      else map.set(row.serviceId, [row.coordinatorId]);
+   }
+   return map;
 }
 
 /**
@@ -87,7 +125,12 @@ export async function listServices(opts?: {
       .where(inArray(services.status, statusFilter))
       .orderBy(desc(services.createdAt));
 
-   return Promise.all(rows.map(buildServiceView));
+   const coordinatorMap = await loadProgramCoordinators(rows.map((r) => r.id));
+   return Promise.all(
+      rows.map((row) =>
+         buildServiceView(row, coordinatorMap.get(row.id) ?? []),
+      ),
+   );
 }
 
 /**
@@ -108,7 +151,174 @@ export async function getService(id: string): Promise<ServiceView | null> {
       .where(and(eq(services.id, id)))
       .limit(1);
    if (!row) return null;
-   return buildServiceView(row);
+   const coordinatorMap = await loadProgramCoordinators([row.id]);
+   return buildServiceView(row, coordinatorMap.get(row.id) ?? []);
+}
+
+/**
+ * List the non-deleted services a given coordinator is responsible for:
+ * private lessons assigned to them via `services.coordinator_id`, plus programs
+ * they are attached to via `program_coordinators`.
+ *
+ * Cached via Next Cache Components; bust via the `services`/`coordinators` tags.
+ */
+export async function listServicesForCoordinator(
+   coordinatorId: string,
+): Promise<ServiceView[]> {
+   "use cache";
+   cacheTag(SERVICES_TAG);
+   cacheTag(COORDINATORS_TAG);
+
+   if (!UUID_RE.test(coordinatorId)) return [];
+
+   const visibleStatuses: ServiceStatus[] = ["active", "disabled", "archived"];
+
+   const programIds = await db
+      .select({ serviceId: programCoordinators.serviceId })
+      .from(programCoordinators)
+      .where(eq(programCoordinators.coordinatorId, coordinatorId));
+
+   const rows = await db
+      .select()
+      .from(services)
+      .where(
+         and(
+            inArray(services.status, visibleStatuses),
+            programIds.length > 0
+               ? or(
+                    eq(services.coordinatorId, coordinatorId),
+                    inArray(
+                       services.id,
+                       programIds.map((p) => p.serviceId),
+                    ),
+                 )
+               : eq(services.coordinatorId, coordinatorId),
+         ),
+      )
+      .orderBy(desc(services.createdAt));
+
+   const coordinatorMap = await loadProgramCoordinators(rows.map((r) => r.id));
+   return Promise.all(
+      rows.map((row) =>
+         buildServiceView(row, coordinatorMap.get(row.id) ?? []),
+      ),
+   );
+}
+
+/**
+ * Whether the given coordinator is responsible for a service — either the
+ * single coordinator on a private lesson, or a member of a program's
+ * `program_coordinators`. Used to authorize the read-only coordinator views.
+ */
+export async function isServiceCoordinator(
+   coordinatorId: string,
+   serviceId: string,
+): Promise<boolean> {
+   if (!UUID_RE.test(coordinatorId) || !UUID_RE.test(serviceId)) return false;
+
+   const [direct] = await db
+      .select({ id: services.id })
+      .from(services)
+      .where(
+         and(
+            eq(services.id, serviceId),
+            eq(services.coordinatorId, coordinatorId),
+         ),
+      )
+      .limit(1);
+   if (direct) return true;
+
+   const [program] = await db
+      .select({ id: programCoordinators.id })
+      .from(programCoordinators)
+      .where(
+         and(
+            eq(programCoordinators.serviceId, serviceId),
+            eq(programCoordinators.coordinatorId, coordinatorId),
+         ),
+      )
+      .limit(1);
+   return Boolean(program);
+}
+
+export type RegistrationAnswer = { prompt: string; answer: string[] };
+
+export type ServiceRegistration = {
+   bookingId: string;
+   registrantName: string;
+   isChild: boolean;
+   status: string;
+   createdAt: Date;
+   answers: RegistrationAnswer[];
+};
+
+/**
+ * List the people registered for a service (from `service_bookings`) together
+ * with their form answers. Child registrations include the answers submitted
+ * for that child; adult registrations have no form answers and show name only.
+ *
+ * Read-only; used by the admin and the coordinator (read-only) services views.
+ */
+export async function listServiceRegistrations(
+   serviceId: string,
+): Promise<ServiceRegistration[]> {
+   if (!UUID_RE.test(serviceId)) return [];
+
+   const rows = await db
+      .select({
+         bookingId: serviceBookings.id,
+         status: serviceBookings.status,
+         createdAt: serviceBookings.createdAt,
+         childId: serviceBookings.childId,
+         childFirstName: children.firstName,
+         childLastName: children.lastName,
+         userFirstName: profiles.firstName,
+         userLastName: profiles.lastName,
+      })
+      .from(serviceBookings)
+      .innerJoin(profiles, eq(profiles.id, serviceBookings.userId))
+      .leftJoin(children, eq(children.id, serviceBookings.childId))
+      .where(eq(serviceBookings.serviceId, serviceId))
+      .orderBy(desc(serviceBookings.createdAt));
+
+   const childIds = rows
+      .map((r) => r.childId)
+      .filter((id): id is string => id !== null);
+
+   const answersByChild = new Map<string, RegistrationAnswer[]>();
+   if (childIds.length > 0) {
+      const answerRows = await db
+         .select({
+            childId: formQuestionAnswers.childId,
+            prompt: formQuestions.prompt,
+            answer: formQuestionAnswers.answer,
+            sortOrder: formQuestions.sortOrder,
+         })
+         .from(formQuestionAnswers)
+         .innerJoin(
+            formQuestions,
+            eq(formQuestions.id, formQuestionAnswers.formQuestionId),
+         )
+         .where(inArray(formQuestionAnswers.childId, childIds))
+         .orderBy(asc(formQuestions.sortOrder));
+
+      for (const a of answerRows) {
+         const list = answersByChild.get(a.childId) ?? [];
+         list.push({ prompt: a.prompt, answer: a.answer });
+         answersByChild.set(a.childId, list);
+      }
+   }
+
+   return rows.map((r) => ({
+      bookingId: r.bookingId,
+      registrantName: r.childId
+         ? `${r.childFirstName ?? ""} ${r.childLastName ?? ""}`.trim()
+         : `${r.userFirstName} ${r.userLastName}`.trim(),
+      isChild: r.childId !== null,
+      status: r.status,
+      createdAt: r.createdAt,
+      answers: r.childId ? (answersByChild.get(r.childId) ?? []) : [],
+   }));
 }
 
 export type CoordinatorOption = {

--- a/app/(authenticated)/services/registrations-dialog.tsx
+++ b/app/(authenticated)/services/registrations-dialog.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import * as React from "react";
+
+import {
+   Dialog,
+   DialogContent,
+   DialogDescription,
+   DialogHeader,
+   DialogTitle,
+} from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Spinner } from "@/components/ui/spinner";
+
+import { fetchServiceRegistrations } from "./actions";
+import type { ServiceRegistration, ServiceView } from "./queries";
+
+export function RegistrationsDialog({
+   service,
+   open,
+   onOpenChange,
+}: {
+   service: ServiceView | null;
+   open: boolean;
+   onOpenChange: (open: boolean) => void;
+}) {
+   const [registrations, setRegistrations] = React.useState<
+      ServiceRegistration[] | null
+   >(null);
+   const [error, setError] = React.useState<string | null>(null);
+   const [pending, startTransition] = React.useTransition();
+
+   React.useEffect(() => {
+      if (!open || !service) return;
+      setRegistrations(null);
+      setError(null);
+      startTransition(async () => {
+         try {
+            const rows = await fetchServiceRegistrations(service.id);
+            setRegistrations(rows);
+         } catch {
+            setError("Could not load registrations.");
+         }
+      });
+   }, [open, service]);
+
+   return (
+      <Dialog open={open} onOpenChange={onOpenChange}>
+         <DialogContent className="sm:max-w-lg">
+            <DialogHeader>
+               <DialogTitle>Registered people</DialogTitle>
+               <DialogDescription>
+                  {service?.title ?? "Service"} — registrations and form answers
+               </DialogDescription>
+            </DialogHeader>
+
+            {pending && (
+               <div className="flex justify-center py-8">
+                  <Spinner className="size-6 text-muted-foreground" />
+               </div>
+            )}
+
+            {error && <p className="text-sm text-destructive">{error}</p>}
+
+            {!pending && !error && registrations && (
+               <ScrollArea className="max-h-[60vh] pr-3">
+                  {registrations.length === 0 ? (
+                     <p className="text-sm text-muted-foreground">
+                        No one has registered for this service yet.
+                     </p>
+                  ) : (
+                     <ul className="flex flex-col gap-4">
+                        {registrations.map((r) => (
+                           <li
+                              key={r.bookingId}
+                              className="rounded-md border border-border p-3"
+                           >
+                              <div className="flex items-center justify-between gap-2">
+                                 <span className="font-medium">
+                                    {r.registrantName || "—"}
+                                 </span>
+                                 <span className="text-xs capitalize text-muted-foreground">
+                                    {r.status}
+                                 </span>
+                              </div>
+                              {r.answers.length > 0 ? (
+                                 <dl className="mt-2 flex flex-col gap-1.5">
+                                    {r.answers.map((a, i) => (
+                                       <div key={i} className="text-sm">
+                                          <dt className="text-muted-foreground">
+                                             {a.prompt}
+                                          </dt>
+                                          <dd>{a.answer.join(", ") || "—"}</dd>
+                                       </div>
+                                    ))}
+                                 </dl>
+                              ) : (
+                                 <p className="mt-1 text-xs text-muted-foreground">
+                                    No form answers.
+                                 </p>
+                              )}
+                           </li>
+                        ))}
+                     </ul>
+                  )}
+               </ScrollArea>
+            )}
+         </DialogContent>
+      </Dialog>
+   );
+}

--- a/app/(authenticated)/services/service-dialog.tsx
+++ b/app/(authenticated)/services/service-dialog.tsx
@@ -3,9 +3,10 @@
 import * as React from "react";
 import { useActionState } from "react";
 import { format } from "date-fns";
-import { CalendarIcon, DollarSign, Plus, X } from "lucide-react";
+import { CalendarIcon, Check, ChevronsUpDown, DollarSign, Plus, X } from "lucide-react";
 import { type DateRange } from "react-day-picker";
 
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ButtonGroup, ButtonGroupText } from "@/components/ui/button-group";
 import { Calendar } from "@/components/ui/calendar";
@@ -240,6 +241,90 @@ function ProgramScheduleFields({
    );
 }
 
+function CoordinatorMultiSelect({
+   coordinators,
+   value,
+   onChange,
+}: {
+   coordinators: CoordinatorOption[];
+   value: string[];
+   onChange: (ids: string[]) => void;
+}) {
+   const [open, setOpen] = React.useState(false);
+   const selected = coordinators.filter((c) => value.includes(c.id));
+   const toggle = (id: string) =>
+      onChange(
+         value.includes(id) ? value.filter((v) => v !== id) : [...value, id],
+      );
+
+   return (
+      <div className="flex flex-col gap-1.5">
+         <Popover open={open} onOpenChange={setOpen}>
+            <PopoverTrigger asChild>
+               <Button
+                  type="button"
+                  variant="outline"
+                  role="combobox"
+                  aria-expanded={open}
+                  className="justify-between font-normal"
+                  disabled={coordinators.length === 0}
+               >
+                  <span className="truncate">
+                     {selected.length === 0
+                        ? coordinators.length === 0
+                           ? "No coordinators available"
+                           : "Select coordinators"
+                        : `${selected.length} selected`}
+                  </span>
+                  <ChevronsUpDown className="size-4 opacity-50" />
+               </Button>
+            </PopoverTrigger>
+            <PopoverContent
+               className="w-[var(--radix-popover-trigger-width)] p-1"
+               align="start"
+            >
+               <div className="max-h-52 overflow-y-auto">
+                  {coordinators.map((c) => {
+                     const isSelected = value.includes(c.id);
+                     return (
+                        <button
+                           key={c.id}
+                           type="button"
+                           onClick={() => toggle(c.id)}
+                           className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm hover:bg-accent"
+                        >
+                           <span className="flex size-4 items-center justify-center">
+                              {isSelected && <Check className="size-4" />}
+                           </span>
+                           <span className="truncate">
+                              {c.firstName} {c.lastName}
+                           </span>
+                        </button>
+                     );
+                  })}
+               </div>
+            </PopoverContent>
+         </Popover>
+         {selected.length > 0 && (
+            <div className="flex flex-wrap gap-1">
+               {selected.map((c) => (
+                  <Badge key={c.id} variant="secondary" className="gap-1">
+                     {c.firstName} {c.lastName}
+                     <button
+                        type="button"
+                        onClick={() => toggle(c.id)}
+                        aria-label={`Remove ${c.firstName} ${c.lastName}`}
+                     >
+                        <X className="size-3" />
+                     </button>
+                  </Badge>
+               ))}
+            </div>
+         )}
+      </div>
+   );
+}
+
 export function ServiceDialog(props: Props) {
    const isEdit = props.mode === "edit";
    const service = isEdit ? props.service : null;
@@ -250,6 +335,9 @@ export function ServiceDialog(props: Props) {
    );
    const [coordinatorId, setCoordinatorId] = React.useState<string>(
       service?.coordinatorId ?? "",
+   );
+   const [coordinatorIds, setCoordinatorIds] = React.useState<string[]>(
+      service?.coordinatorIds ?? [],
    );
    const [title, setTitle] = React.useState<string>(service?.title ?? "");
    const [description, setDescription] = React.useState<string>(
@@ -270,6 +358,7 @@ export function ServiceDialog(props: Props) {
       if (service) {
          setType(service.type);
          setCoordinatorId(service.coordinatorId ?? "");
+         setCoordinatorIds(service.coordinatorIds ?? []);
          setTitle(service.title ?? "");
          setDescription(service.description ?? "");
          setDurationMinutes(String(service.durationMinutes ?? 60));
@@ -289,6 +378,7 @@ export function ServiceDialog(props: Props) {
             closeRef.current?.click();
             setType("programs");
             setCoordinatorId("");
+            setCoordinatorIds([]);
             setTitle("");
             setDescription("");
             setDurationMinutes("60");
@@ -325,7 +415,7 @@ export function ServiceDialog(props: Props) {
                <DialogDescription>
                   {isEdit
                      ? "Update fields below. Only changed fields are saved."
-                     : "Create a coaching session or bookable service. Pricing is stored in Stripe."}
+                     : "Create a program or private lesson. Pricing is stored in Stripe."}
                </DialogDescription>
             </DialogHeader>
 
@@ -432,10 +522,26 @@ export function ServiceDialog(props: Props) {
                   </div>
 
                   {type === "programs" && (
-                     <ProgramScheduleFields
-                        initial={initialSchedule}
-                        errors={errors}
-                     />
+                     <>
+                        <ProgramScheduleFields
+                           initial={initialSchedule}
+                           errors={errors}
+                        />
+                        <div className="flex flex-col gap-1.5">
+                           <Label>Coordinators</Label>
+                           <input
+                              type="hidden"
+                              name="coordinator_ids"
+                              value={JSON.stringify(coordinatorIds)}
+                           />
+                           <CoordinatorMultiSelect
+                              coordinators={coordinators}
+                              value={coordinatorIds}
+                              onChange={setCoordinatorIds}
+                           />
+                           <FieldError messages={errors?.coordinator_ids} />
+                        </div>
+                     </>
                   )}
 
                   {type === "private_lessons" && (

--- a/app/(authenticated)/services/services-data-table.tsx
+++ b/app/(authenticated)/services/services-data-table.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { ColumnDef } from "@tanstack/react-table";
-import { Archive, ArchiveRestore, Ban, Pencil, Power } from "lucide-react";
+import { Archive, ArchiveRestore, Ban, Pencil, Power, Users } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -20,9 +20,13 @@ import type { ServiceView } from "@/app/(authenticated)/services/queries";
 export function ServicesDataTable({
    services,
    onEdit,
+   onViewRegistrations,
+   readOnly = false,
 }: {
    services: ServiceView[];
    onEdit: (service: ServiceView) => void;
+   onViewRegistrations?: (service: ServiceView) => void;
+   readOnly?: boolean;
 }) {
    const [pending, startTransition] = React.useTransition();
 
@@ -82,6 +86,25 @@ export function ServicesDataTable({
             header: () => <div className="text-right">Actions</div>,
             cell: ({ row }) => {
                const s = row.original;
+               if (readOnly) {
+                  return (
+                     <div className="flex items-center justify-end gap-0.5">
+                        <Tooltip>
+                           <TooltipTrigger asChild>
+                              <Button
+                                 variant="ghost"
+                                 size="icon-sm"
+                                 aria-label="View registrations"
+                                 onClick={() => onViewRegistrations?.(s)}
+                              >
+                                 <Users />
+                              </Button>
+                           </TooltipTrigger>
+                           <TooltipContent>View registrations</TooltipContent>
+                        </Tooltip>
+                     </div>
+                  );
+               }
                return (
                   <div className="flex items-center justify-end gap-0.5">
                      {(s.status === "active" || s.status === "disabled") && (
@@ -168,7 +191,7 @@ export function ServicesDataTable({
             },
          },
       ],
-      [pending, runStatus, onEdit],
+      [pending, runStatus, onEdit, onViewRegistrations, readOnly],
    );
 
    return (

--- a/app/(authenticated)/services/services-table.tsx
+++ b/app/(authenticated)/services/services-table.tsx
@@ -6,6 +6,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 import { ServiceDialog } from "./service-dialog";
 import { ServicesDataTable } from "./services-data-table";
+import { RegistrationsDialog } from "./registrations-dialog";
 import type { CoordinatorOption, ServiceView } from "./queries";
 
 type StatusTab = "all" | "active" | "disabled" | "archived";
@@ -13,12 +14,15 @@ type StatusTab = "all" | "active" | "disabled" | "archived";
 export function ServicesTable({
    services,
    coordinators,
+   readOnly = false,
 }: {
    services: ServiceView[];
    coordinators: CoordinatorOption[];
+   readOnly?: boolean;
 }) {
    const [tab, setTab] = React.useState<StatusTab>("active");
    const [editing, setEditing] = React.useState<ServiceView | null>(null);
+   const [viewing, setViewing] = React.useState<ServiceView | null>(null);
    const statusTabs: StatusTab[] = ["all", "active", "disabled", "archived"];
 
    const filtered = React.useMemo(() => {
@@ -42,22 +46,39 @@ export function ServicesTable({
                      </TabsTrigger>
                   ))}
                </TabsList>
-               <ServiceDialog mode="add" coordinators={coordinators} />
+               {!readOnly && (
+                  <ServiceDialog mode="add" coordinators={coordinators} />
+               )}
             </div>
 
             <TabsContent value={tab}>
-               <ServicesDataTable services={filtered} onEdit={setEditing} />
+               <ServicesDataTable
+                  services={filtered}
+                  onEdit={setEditing}
+                  onViewRegistrations={setViewing}
+                  readOnly={readOnly}
+               />
             </TabsContent>
          </Tabs>
-         <ServiceDialog
-            mode="edit"
-            coordinators={coordinators}
-            service={editing}
-            open={editing !== null}
-            onOpenChange={(v) => {
-               if (!v) setEditing(null);
-            }}
-         />
+         {readOnly ? (
+            <RegistrationsDialog
+               service={viewing}
+               open={viewing !== null}
+               onOpenChange={(v) => {
+                  if (!v) setViewing(null);
+               }}
+            />
+         ) : (
+            <ServiceDialog
+               mode="edit"
+               coordinators={coordinators}
+               service={editing}
+               open={editing !== null}
+               onOpenChange={(v) => {
+                  if (!v) setEditing(null);
+               }}
+            />
+         )}
       </>
    );
 }

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -2,14 +2,14 @@ import { NextRequest, NextResponse } from "next/server";
 import { deleteCouponIfExhausted, stripe, syncStripeData } from "@/lib/stripe";
 import { db } from "@/lib/db";
 import {
-   coachingSessions,
+   privateLessonSessions,
    profiles,
    purchases,
    serviceBookings,
 } from "@/lib/db/schema";
 import { and, eq } from "drizzle-orm";
 import Stripe from "stripe";
-import { sendCoordinatorBookingEmail } from "@/app/coaching/notifications";
+import { sendCoordinatorBookingEmail } from "@/app/private-lessons/notifications";
 
 const allowedEvents: Stripe.Event.Type[] = [
    "checkout.session.completed",
@@ -51,17 +51,17 @@ export async function POST(request: NextRequest) {
       const session = event.data.object as Stripe.Checkout.Session;
       const metadata = session.metadata ?? {};
 
-      if (metadata.type === "private_lesson" && metadata.coachingSessionId) {
+      if (metadata.type === "private_lesson" && metadata.privateLessonSessionId) {
          const updated = await db
-            .update(coachingSessions)
+            .update(privateLessonSessions)
             .set({ status: "pending", stripeOrderId: session.id })
             .where(
                and(
-                  eq(coachingSessions.id, metadata.coachingSessionId),
-                  eq(coachingSessions.status, "awaiting_payment"),
+                  eq(privateLessonSessions.id, metadata.privateLessonSessionId),
+                  eq(privateLessonSessions.status, "awaiting_payment"),
                ),
             )
-            .returning({ id: coachingSessions.id });
+            .returning({ id: privateLessonSessions.id });
 
          const transitioned = updated[0];
          if (transitioned) {

--- a/app/checkout/actions.ts
+++ b/app/checkout/actions.ts
@@ -5,7 +5,11 @@ import { and, eq } from "drizzle-orm";
 import type Stripe from "stripe";
 
 import { db } from "@/lib/db";
-import { coachingSessions, serviceBookings, services } from "@/lib/db/schema";
+import {
+   privateLessonSessions,
+   serviceBookings,
+   services,
+} from "@/lib/db/schema";
 import {
    getActiveCouponForCustomerProduct,
    getOrCreateStripeCustomer,
@@ -14,7 +18,7 @@ import {
 import {
    submitAvailabilities,
    type Availability,
-} from "@/app/coaching/actions";
+} from "@/app/private-lessons/actions";
 import { createClient } from "@/utils/supabase/server";
 
 export type CheckoutResult = { url: string } | { error: string };
@@ -135,10 +139,10 @@ export async function checkoutServiceBooking({
    return { url: result.session.url! };
 }
 
-export async function checkoutCoachingSession({
-   coachingSessionId,
+export async function checkoutPrivateLessonSession({
+   privateLessonSessionId,
 }: {
-   coachingSessionId: string;
+   privateLessonSessionId: string;
 }): Promise<CheckoutResult> {
    const supabase = await createClient();
    const {
@@ -146,15 +150,15 @@ export async function checkoutCoachingSession({
    } = await supabase.auth.getUser();
    if (!user) return { error: "Not authenticated" };
 
-   const row = await db.query.coachingSessions.findFirst({
+   const row = await db.query.privateLessonSessions.findFirst({
       where: and(
-         eq(coachingSessions.id, coachingSessionId),
-         eq(coachingSessions.userId, user.id),
+         eq(privateLessonSessions.id, privateLessonSessionId),
+         eq(privateLessonSessions.userId, user.id),
       ),
    });
-   if (!row) return { error: "Coaching session not found" };
+   if (!row) return { error: "Private lesson session not found" };
    if (row.status !== "awaiting_payment")
-      return { error: "Coaching session is not awaiting payment" };
+      return { error: "Private lesson session is not awaiting payment" };
 
    const service = await db.query.services.findFirst({
       where: eq(services.id, row.serviceId),
@@ -167,18 +171,20 @@ export async function checkoutCoachingSession({
       stripeProductId: service.stripeProductId,
       metadata: {
          type: "private_lesson",
-         coachingSessionId: row.id,
+         privateLessonSessionId: row.id,
       },
    });
    if ("error" in result) {
-      await db.delete(coachingSessions).where(eq(coachingSessions.id, row.id));
+      await db
+         .delete(privateLessonSessions)
+         .where(eq(privateLessonSessions.id, row.id));
       return { error: result.error };
    }
 
    await db
-      .update(coachingSessions)
+      .update(privateLessonSessions)
       .set({ stripeOrderId: result.session.id })
-      .where(eq(coachingSessions.id, row.id));
+      .where(eq(privateLessonSessions.id, row.id));
 
    return { url: result.session.url! };
 }
@@ -193,7 +199,7 @@ export async function startPrivateLessonCheckout({
    const created = await submitAvailabilities({ serviceId, availabilities });
    if ("error" in created) return { error: created.error };
 
-   return checkoutCoachingSession({
-      coachingSessionId: created.coachingSessionId,
+   return checkoutPrivateLessonSession({
+      privateLessonSessionId: created.privateLessonSessionId,
    });
 }

--- a/app/private-lessons/actions.ts
+++ b/app/private-lessons/actions.ts
@@ -3,13 +3,13 @@
 import { eq } from "drizzle-orm";
 
 import { db } from "@/lib/db";
-import { coachingSessions, services } from "@/lib/db/schema";
+import { privateLessonSessions, services } from "@/lib/db/schema";
 import { createClient } from "@/utils/supabase/server";
 
 export type Availability = { start: string; end: string };
 
 export type SubmitAvailabilitiesResult =
-   | { coachingSessionId: string }
+   | { privateLessonSessionId: string }
    | { error: string };
 
 export async function submitAvailabilities({
@@ -40,7 +40,7 @@ export async function submitAvailabilities({
       return { error: "Service has no coordinator assigned" };
 
    const [row] = await db
-      .insert(coachingSessions)
+      .insert(privateLessonSessions)
       .values({
          userId: user.id,
          serviceId: service.id,
@@ -48,7 +48,7 @@ export async function submitAvailabilities({
          selectedTimeSlots: availabilities,
          status: "awaiting_payment",
       })
-      .returning({ id: coachingSessions.id });
+      .returning({ id: privateLessonSessions.id });
 
-   return { coachingSessionId: row.id };
+   return { privateLessonSessionId: row.id };
 }

--- a/app/private-lessons/notifications.ts
+++ b/app/private-lessons/notifications.ts
@@ -6,7 +6,7 @@ import { pgSchema, uuid, text } from "drizzle-orm/pg-core";
 import { db } from "@/lib/db";
 import {
    children,
-   coachingSessions,
+   privateLessonSessions,
    emergencyContacts,
    formQuestionAnswers,
    formQuestions,
@@ -105,8 +105,8 @@ export async function sendCoordinatorBookingEmail(
    try {
       const [session] = await db
          .select()
-         .from(coachingSessions)
-         .where(eq(coachingSessions.id, sessionId))
+         .from(privateLessonSessions)
+         .where(eq(privateLessonSessions.id, sessionId))
          .limit(1);
       if (!session) {
          console.error(

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -10,7 +10,9 @@ import {
    MonitorSmartphone,
    Settings,
    Form,
+   CalendarClock,
 } from "lucide-react";
+import { ROLES, type Role } from "@/lib/roles";
 import {
    Sidebar,
    SidebarContent,
@@ -26,20 +28,28 @@ import {
 import Image from "next/image";
 import { cn } from "@/lib/utils";
 
-const navItems = [
+const adminNavItems = [
    { title: "OVERVIEW", href: "/", icon: LayoutGrid },
    { title: "SERVICES", href: "/services", icon: BookOpen },
    { title: "USERS", href: "/users", icon: Users },
    { title: "FINANCE", href: "/finance", icon: CreditCard },
    { title: "MEMBERSHIPS", href: "/memberships", icon: MonitorSmartphone },
-   { title: "FORMS" , href: "/forms", icon: Form}
+   { title: "FORMS", href: "/forms", icon: Form },
+];
+
+const coordinatorNavItems = [
+   { title: "SERVICES", href: "/services", icon: BookOpen },
+   { title: "SCHEDULED LESSONS", href: "/scheduled-lessons", icon: CalendarClock },
 ];
 
 export function AppSidebar({
+   role,
    className,
    ...props
-}: React.ComponentProps<typeof Sidebar>) {
+}: React.ComponentProps<typeof Sidebar> & { role: Role }) {
    const pathname = usePathname();
+   const navItems =
+      role === ROLES.COORDINATOR ? coordinatorNavItems : adminNavItems;
 
    return (
       <Sidebar

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -38,6 +38,7 @@ const adminNavItems = [
 ];
 
 const coordinatorNavItems = [
+   { title: "OVERVIEW", href: "/", icon: LayoutGrid },
    { title: "SERVICES", href: "/services", icon: BookOpen },
    { title: "SCHEDULED LESSONS", href: "/scheduled-lessons", icon: CalendarClock },
 ];

--- a/docs/private-lessons.md
+++ b/docs/private-lessons.md
@@ -1,13 +1,14 @@
-# Coaching Sessions Table
+# Private Lesson Sessions Table
 
-One-on-one sessions booked between a user and a coach. Linked to a `coaching_session`-type entry in `services`.
+One-on-one sessions booked between a user and a coordinator. Linked to a
+`private_lessons`-type entry in `services`.
 
 ```mermaid
 erDiagram
-    coaching_sessions {
+    private_lesson_sessions {
         uuid id PK
         uuid service_id FK
-        uuid coach_id FK
+        uuid coordinator_id FK
         uuid user_id FK
         timestamp scheduled_at "null until a slot is confirmed"
         int duration_minutes
@@ -19,14 +20,14 @@ erDiagram
         timestamp updated_at
     }
 
-    profiles ||--o{ coaching_sessions : "coach leads"
-    profiles ||--o{ coaching_sessions : "user attends"
-    services ||--o{ coaching_sessions : "fulfilled by"
+    profiles ||--o{ private_lesson_sessions : "coordinator leads"
+    profiles ||--o{ private_lesson_sessions : "user attends"
+    services ||--o{ private_lesson_sessions : "fulfilled by"
 ```
 
 ## Notes
 
 - `scheduled_at` is null by default — it is set once the user selects a specific slot from `selected_time_slots`.
 - `selected_time_slots` is a JSON array of `{ start, end }` objects (ISO 8601 strings) representing the time options offered to the user e.g. `[{ "start": "2026-04-14T14:00:00Z", "end": "2026-04-14T17:00:00Z" }]`.
-- `meeting_url` is provided by the coach after confirmation.
+- `meeting_url` is provided by the coordinator after confirmation.
 - `status = completed` is set after the session ends.

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -9,7 +9,7 @@ erDiagram
         text first_name
         text last_name
         text stripe_customer_id "unique"
-        role role "user | admin | coach"
+        role role "user | admin | coordinator"
         timestamp created_at
         timestamp updated_at
         timestamp last_login_at
@@ -19,4 +19,4 @@ erDiagram
 ## Notes
 
 - `id` is **not** auto-generated — it is set to the corresponding `auth.users.id` from Supabase Auth.
-- `role` controls access: `user` is a regular member, `coach` can manage and lead sessions, `admin` has full access.
+- `role` controls access: `user` is a regular member, `coordinator` manages and leads the services they are assigned to (read-only dashboard scoped to those services), `admin` has full access.

--- a/docs/schema-overview.md
+++ b/docs/schema-overview.md
@@ -29,7 +29,7 @@ erDiagram
         int duration_minutes
         text stripe_product_id
         service_status status
-        uuid coach_id FK "null for programs"
+        uuid coordinator_id FK "private lessons only; programs use program_coordinators"
         uuid form_id FK "nullable"
         boolean is_for_children
         timestamp created_at
@@ -61,10 +61,10 @@ erDiagram
         timestamp updated_at
     }
 
-    coaching_sessions {
+    private_lesson_sessions {
         uuid id PK
         uuid service_id FK
-        uuid coach_id FK
+        uuid coordinator_id FK
         uuid user_id FK
         uuid child_id FK "nullable; null means adult registration"
         timestamp scheduled_at "set when slot is confirmed"
@@ -72,12 +72,16 @@ erDiagram
         text meeting_url
         text notes
         jsonb selected_time_slots "array of {start, end} objects"
-        jsonb coach_time_slots
-        text coach_token
-        text client_token
         text stripe_order_id
         timestamp created_at
         timestamp updated_at
+    }
+
+    program_coordinators {
+        uuid id PK
+        uuid service_id FK
+        uuid coordinator_id FK
+        timestamp created_at
     }
 
     subscriptions {
@@ -153,15 +157,17 @@ erDiagram
     profiles ||--o{ service_bookings : "books"
     services ||--o{ service_bookings : "booked via"
     children |o--o{ service_bookings : "registered for"
-    profiles ||--o{ coaching_sessions : "coaches"
-    profiles ||--o{ coaching_sessions : "attends"
-    services ||--o{ coaching_sessions : "fulfilled by"
-    children |o--o{ coaching_sessions : "registered for"
+    profiles ||--o{ private_lesson_sessions : "coordinates"
+    profiles ||--o{ private_lesson_sessions : "attends"
+    services ||--o{ private_lesson_sessions : "fulfilled by"
+    children |o--o{ private_lesson_sessions : "registered for"
     profiles ||--o{ children : "parent of"
     children ||--o{ emergency_contacts : "has"
     profiles ||--o| subscriptions : "has"
     profiles ||--o{ purchases : "makes"
-    profiles |o--o{ services : "coaches"
+    profiles |o--o{ services : "coordinates (private lessons)"
+    services ||--o{ program_coordinators : "assigned via"
+    profiles ||--o{ program_coordinators : "coordinates (programs)"
     forms ||--o{ form_questions : "contains"
     services }o--o| forms : "uses"
     form_questions ||--o{ form_question_answers : "answered via"
@@ -173,12 +179,13 @@ erDiagram
 | Table | Index | Type | Condition |
 |---|---|---|---|
 | `service_bookings` | `service_bookings_service_id_child_id_idx` | Unique (partial) | `WHERE child_id IS NOT NULL` — prevents the same child from registering for the same program twice |
+| `program_coordinators` | `program_coordinators_service_id_coordinator_id_idx` | Unique | prevents assigning the same coordinator to a program twice |
 
 ## Enums
 
 | Enum | Values |
 |---|---|
-| `role` | `user`, `admin`, `coach` |
+| `role` | `user`, `admin`, `coordinator` |
 | `service_type` | `private_lessons`, `programs` |
 | `service_status` | `active`, `disabled`, `archived`, `deleted` |
 | `booking_status` | `awaiting_payment`, `pending`, `confirmed`, `cancelled` |

--- a/docs/services.md
+++ b/docs/services.md
@@ -3,8 +3,8 @@
 ## Services
 
 The central catalog of offerings on the platform. Two types:
-- **`booking`** — a fixed event with predetermined time slots set by the admin. Users buy it like a product with no input on timing. `scheduled_at` holds the time slots as a JSON array.
-- **`coaching_session`** — a coaching offering where the user proposes availability. `scheduled_at` is null — timing is handled through the `coaching_sessions` table.
+- **`programs`** — a scheduled offering with a weekly recurring schedule (`slots`) over a `start_date`/`end_date` range. One or more coordinators are assigned via the `program_coordinators` join table.
+- **`private_lessons`** — a one-on-one offering where the user proposes availability. Timing is handled through the `private_lesson_sessions` table, and a single coordinator is assigned via `services.coordinator_id`.
 
 ```mermaid
 erDiagram
@@ -12,8 +12,8 @@ erDiagram
         uuid id PK
         text title
         text description
-        service_type type "coaching_session | booking"
-        jsonb scheduled_at "array of {start, end} objects — null for coaching_session"
+        service_type type "programs | private_lessons"
+        uuid coordinator_id FK "private lessons only; programs use program_coordinators"
         int duration_minutes
         int price "in cents"
         boolean is_active

--- a/drizzle/0002_coordinator_rename_and_dashboard.sql
+++ b/drizzle/0002_coordinator_rename_and_dashboard.sql
@@ -1,0 +1,24 @@
+ALTER TYPE "public"."role" RENAME VALUE 'coach' TO 'coordinator';--> statement-breakpoint
+ALTER TABLE "coaching_sessions" RENAME TO "private_lesson_sessions";--> statement-breakpoint
+ALTER TABLE "services" RENAME COLUMN "coach_id" TO "coordinator_id";--> statement-breakpoint
+ALTER TABLE "private_lesson_sessions" RENAME COLUMN "coach_id" TO "coordinator_id";--> statement-breakpoint
+ALTER TABLE "services" RENAME CONSTRAINT "services_coach_id_profiles_id_fk" TO "services_coordinator_id_profiles_id_fk";--> statement-breakpoint
+ALTER TABLE "services" RENAME CONSTRAINT "services_private_lessons_require_coach" TO "services_private_lessons_require_coordinator";--> statement-breakpoint
+ALTER TABLE "private_lesson_sessions" RENAME CONSTRAINT "coaching_sessions_service_id_services_id_fk" TO "private_lesson_sessions_service_id_services_id_fk";--> statement-breakpoint
+ALTER TABLE "private_lesson_sessions" RENAME CONSTRAINT "coaching_sessions_coach_id_profiles_id_fk" TO "private_lesson_sessions_coordinator_id_profiles_id_fk";--> statement-breakpoint
+ALTER TABLE "private_lesson_sessions" RENAME CONSTRAINT "coaching_sessions_user_id_profiles_id_fk" TO "private_lesson_sessions_user_id_profiles_id_fk";--> statement-breakpoint
+ALTER TABLE "private_lesson_sessions" RENAME CONSTRAINT "coaching_sessions_child_id_children_id_fk" TO "private_lesson_sessions_child_id_children_id_fk";--> statement-breakpoint
+ALTER TABLE "private_lesson_sessions" RENAME CONSTRAINT "coaching_sessions_stripe_order_id_unique" TO "private_lesson_sessions_stripe_order_id_unique";--> statement-breakpoint
+ALTER TABLE "private_lesson_sessions" DROP COLUMN "coach_time_slots";--> statement-breakpoint
+ALTER TABLE "private_lesson_sessions" DROP COLUMN "coach_token";--> statement-breakpoint
+ALTER TABLE "private_lesson_sessions" DROP COLUMN "client_token";--> statement-breakpoint
+CREATE TABLE "program_coordinators" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"service_id" uuid NOT NULL,
+	"coordinator_id" uuid NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "program_coordinators" ADD CONSTRAINT "program_coordinators_service_id_services_id_fk" FOREIGN KEY ("service_id") REFERENCES "public"."services"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "program_coordinators" ADD CONSTRAINT "program_coordinators_coordinator_id_profiles_id_fk" FOREIGN KEY ("coordinator_id") REFERENCES "public"."profiles"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "program_coordinators_service_id_coordinator_id_idx" ON "program_coordinators" USING btree ("service_id","coordinator_id");

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,1340 @@
+{
+  "id": "96545282-27c9-4fd3-bbc9-9c1de81430f8",
+  "prevId": "c5417e97-8724-4ca5-9531-d1c2ba511d23",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.children": {
+      "name": "children",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dob": {
+          "name": "dob",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_conditions": {
+          "name": "medical_conditions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medications": {
+          "name": "medications",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "children_parent_id_profiles_id_fk": {
+          "name": "children_parent_id_profiles_id_fk",
+          "tableFrom": "children",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.emergency_contacts": {
+      "name": "emergency_contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_address": {
+          "name": "email_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "emergency_contacts_child_id_children_id_fk": {
+          "name": "emergency_contacts_child_id_children_id_fk",
+          "tableFrom": "emergency_contacts",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_question_answers": {
+      "name": "form_question_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_question_id": {
+          "name": "form_question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_question_answers_form_question_id_form_questions_id_fk": {
+          "name": "form_question_answers_form_question_id_form_questions_id_fk",
+          "tableFrom": "form_question_answers",
+          "tableTo": "form_questions",
+          "columnsFrom": [
+            "form_question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_question_answers_child_id_children_id_fk": {
+          "name": "form_question_answers_child_id_children_id_fk",
+          "tableFrom": "form_question_answers",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_questions": {
+      "name": "form_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "form_question_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_questions_form_id_forms_id_fk": {
+          "name": "form_questions_form_id_forms_id_fk",
+          "tableFrom": "form_questions",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forms": {
+      "name": "forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_stripe_customer_id_unique": {
+          "name": "profiles_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.purchases": {
+      "name": "purchases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_session_id": {
+          "name": "stripe_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "purchases_user_id_profiles_id_fk": {
+          "name": "purchases_user_id_profiles_id_fk",
+          "tableFrom": "purchases",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "purchases_stripe_session_id_unique": {
+          "name": "purchases_stripe_session_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_session_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_bookings": {
+      "name": "service_bookings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "booking_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "stripe_order_id": {
+          "name": "stripe_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "service_bookings_service_id_child_id_idx": {
+          "name": "service_bookings_service_id_child_id_idx",
+          "columns": [
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"service_bookings\".\"child_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "service_bookings_user_id_profiles_id_fk": {
+          "name": "service_bookings_user_id_profiles_id_fk",
+          "tableFrom": "service_bookings",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "service_bookings_service_id_services_id_fk": {
+          "name": "service_bookings_service_id_services_id_fk",
+          "tableFrom": "service_bookings",
+          "tableTo": "services",
+          "columnsFrom": [
+            "service_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "service_bookings_child_id_children_id_fk": {
+          "name": "service_bookings_child_id_children_id_fk",
+          "tableFrom": "service_bookings",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "service_bookings_stripe_order_id_unique": {
+          "name": "service_bookings_stripe_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "service_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slots": {
+          "name": "slots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "service_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_for_children": {
+          "name": "is_for_children",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "coordinator_id": {
+          "name": "coordinator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "services_form_id_forms_id_fk": {
+          "name": "services_form_id_forms_id_fk",
+          "tableFrom": "services",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "services_coordinator_id_profiles_id_fk": {
+          "name": "services_coordinator_id_profiles_id_fk",
+          "tableFrom": "services",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "coordinator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "services_private_lessons_require_coordinator": {
+          "name": "services_private_lessons_require_coordinator",
+          "value": "\"services\".\"type\" <> 'private_lessons' OR \"services\".\"coordinator_id\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "payment_method_brand": {
+          "name": "payment_method_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_last4": {
+          "name": "payment_method_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscriptions_user_id_profiles_id_fk": {
+          "name": "subscriptions_user_id_profiles_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_user_id_unique": {
+          "name": "subscriptions_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "subscriptions_stripe_subscription_id_unique": {
+          "name": "subscriptions_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webinars": {
+      "name": "webinars",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "webinar_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "youtube_url": {
+          "name": "youtube_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.private_lesson_sessions": {
+      "name": "private_lesson_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coordinator_id": {
+          "name": "coordinator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "meeting_url": {
+          "name": "meeting_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_time_slots": {
+          "name": "selected_time_slots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_order_id": {
+          "name": "stripe_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "private_lesson_sessions_service_id_services_id_fk": {
+          "name": "private_lesson_sessions_service_id_services_id_fk",
+          "tableFrom": "private_lesson_sessions",
+          "tableTo": "services",
+          "columnsFrom": [
+            "service_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "private_lesson_sessions_coordinator_id_profiles_id_fk": {
+          "name": "private_lesson_sessions_coordinator_id_profiles_id_fk",
+          "tableFrom": "private_lesson_sessions",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "coordinator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "private_lesson_sessions_user_id_profiles_id_fk": {
+          "name": "private_lesson_sessions_user_id_profiles_id_fk",
+          "tableFrom": "private_lesson_sessions",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "private_lesson_sessions_child_id_children_id_fk": {
+          "name": "private_lesson_sessions_child_id_children_id_fk",
+          "tableFrom": "private_lesson_sessions",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "private_lesson_sessions_stripe_order_id_unique": {
+          "name": "private_lesson_sessions_stripe_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.program_coordinators": {
+      "name": "program_coordinators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coordinator_id": {
+          "name": "coordinator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "program_coordinators_service_id_coordinator_id_idx": {
+          "name": "program_coordinators_service_id_coordinator_id_idx",
+          "columns": [
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coordinator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "program_coordinators_service_id_services_id_fk": {
+          "name": "program_coordinators_service_id_services_id_fk",
+          "tableFrom": "program_coordinators",
+          "tableTo": "services",
+          "columnsFrom": [
+            "service_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_coordinators_coordinator_id_profiles_id_fk": {
+          "name": "program_coordinators_coordinator_id_profiles_id_fk",
+          "tableFrom": "program_coordinators",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "coordinator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.booking_status": {
+      "name": "booking_status",
+      "schema": "public",
+      "values": [
+        "awaiting_payment",
+        "pending",
+        "confirmed",
+        "cancelled"
+      ]
+    },
+    "public.form_question_type": {
+      "name": "form_question_type",
+      "schema": "public",
+      "values": [
+        "text",
+        "multiple_choices",
+        "checkboxes",
+        "user_agreement"
+      ]
+    },
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "male",
+        "female",
+        "prefer_not_to_say"
+      ]
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin",
+        "coordinator"
+      ]
+    },
+    "public.service_status": {
+      "name": "service_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "archived",
+        "deleted",
+        "disabled"
+      ]
+    },
+    "public.service_type": {
+      "name": "service_type",
+      "schema": "public",
+      "values": [
+        "private_lessons",
+        "programs"
+      ]
+    },
+    "public.session_status": {
+      "name": "session_status",
+      "schema": "public",
+      "values": [
+        "awaiting_payment",
+        "pending",
+        "confirmed",
+        "cancelled",
+        "completed"
+      ]
+    },
+    "public.webinar_tier": {
+      "name": "webinar_tier",
+      "schema": "public",
+      "values": [
+        "free",
+        "premium"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1781590709369,
       "tag": "0001_magical_cloak",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1781849600000,
+      "tag": "0002_coordinator_rename_and_dashboard",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/auth/require-admin.ts
+++ b/lib/auth/require-admin.ts
@@ -1,10 +1,29 @@
 import { createClient } from "@/utils/supabase/server";
-import { ROLES } from "@/lib/roles";
+import { ROLES, type Role } from "@/lib/roles";
 
-export async function requireAdmin(): Promise<void> {
+/**
+ * Resolve the current user's role from Supabase auth claims, or null if the
+ * user is unauthenticated / has no role claim.
+ */
+export async function getUserRole(): Promise<Role | null> {
    const supabase = await createClient();
    const { data } = await supabase.auth.getClaims();
-   if (data?.claims?.user_role !== ROLES.ADMIN) {
+   const role = data?.claims?.user_role;
+   if (role === ROLES.ADMIN || role === ROLES.COORDINATOR || role === ROLES.USER)
+      return role;
+   return null;
+}
+
+export async function requireAdmin(): Promise<void> {
+   const role = await getUserRole();
+   if (role !== ROLES.ADMIN) {
+      throw new Error("Forbidden");
+   }
+}
+
+export async function requireCoordinatorOrAdmin(): Promise<void> {
+   const role = await getUserRole();
+   if (role !== ROLES.ADMIN && role !== ROLES.COORDINATOR) {
       throw new Error("Forbidden");
    }
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -148,7 +148,27 @@ export const webinars = pgTable("webinars", {
    updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });
 
-export const coachingSessions = pgTable("coaching_sessions", {
+export const programCoordinators = pgTable(
+   "program_coordinators",
+   {
+      id: uuid("id").primaryKey().defaultRandom(),
+      serviceId: uuid("service_id")
+         .references(() => services.id, { onDelete: "cascade" })
+         .notNull(),
+      coordinatorId: uuid("coordinator_id")
+         .references(() => profiles.id, { onDelete: "restrict" })
+         .notNull(),
+      createdAt: timestamp("created_at").defaultNow().notNull(),
+   },
+   (t) => [
+      uniqueIndex("program_coordinators_service_id_coordinator_id_idx").on(
+         t.serviceId,
+         t.coordinatorId,
+      ),
+   ],
+);
+
+export const privateLessonSessions = pgTable("private_lesson_sessions", {
    id: uuid("id").primaryKey().defaultRandom(),
    serviceId: uuid("service_id")
       .references(() => services.id, { onDelete: "cascade" })


### PR DESCRIPTION
Closes #88

### Overview

This ticket replaces the "coach" concept with "coordinator", lets programs have multiple coordinators, and gives coordinators their own scoped dashboard.

- **Full rename (coach → coordinator):** the `coaching_sessions` table is renamed to `private_lesson_sessions` (and the Drizzle `coachingSessions` export → `privateLessonSessions`). `services.coordinator_id` and `private_lesson_sessions.coordinator_id` are used throughout. All remaining code, server actions (`app/coaching` → `app/private-lessons`), Stripe webhook metadata keys, UI copy, and docs are updated. The role enum and `coordinator_id` columns were already partially renamed on `develop`; this PR finishes the rename. No `coach`/`coach_id`/`coaching_sessions` references remain in code or docs (only in immutable migration history, which is expected).
- **Multiple coordinators on programs:** new `program_coordinators` many-to-many join table (`service_id` → `services.id`, `coordinator_id` → `profiles.id`, unique per pair). The program create/edit dialog now has a multi-select for coordinators. Private lessons keep their single `services.coordinator_id`.
- **Coordinator dashboard:** the sidebar is role-filtered — coordinators see **Overview · Services · Scheduled lessons**.
  - *Overview* is the shared landing page. For coordinators there's only the Welcome / Sign out card.
  - *Services* reuses the existing admin services tab, rendered read-only and scoped to the services they coordinate. Each service exposes a read-only "View registrations" view listing registered people and their form answers.
  - *Scheduled lessons* lists their upcoming `private_lesson_sessions` with scheduling details (`scheduled_at`, `meeting_url`, requested `selected_time_slots`).
- **Migration & docs:** Drizzle migration `0002_coordinator_rename_and_dashboard.sql` (data-preserving `ALTER ... RENAME` + `program_coordinators`) with matching snapshot; `drizzle-kit check` passes. Schema docs updated (`schema-overview.md`, `profiles.md`, `services.md`, `coaching.md` → `private-lessons.md`).

### Testing

- **Unit tests** (`__tests__/services-actions.test.ts`): updated for the rename and added cases for assigning multiple coordinators to a program (create) and replacing program coordinators (update). Full suite: **14/14 passing**.
- **Static checks:** `eslint` (0 errors), `tsc --noEmit` (clean aside from pre-existing `@react-email` module errors unrelated to this PR), `drizzle-kit check` passes.
- **Manual testing** against the dev DB:
  - Verified DB state: `role` enum = `user, admin, coordinator` (no `coach`); `services.coordinator_id`, `private_lesson_sessions.coordinator_id`, `private_lesson_sessions` table, and `program_coordinators` all exist; `coaching_sessions` is gone.
  - Verified coordinator-scoping queries against real data: services scope correctly to the logged-in coordinator, registrations + form answers load per service, and upcoming lessons return the coordinator's pending/confirmed sessions.
  - As an admin: created/edited a program with multiple coordinators and a private lesson with a single coordinator; confirmed the Overview still shows Welcome + Subscription + Product.
  - As a coordinator: sidebar shows only Overview/Services/Scheduled lessons; Overview shows only the Welcome/Sign out card; Services is read-only and scoped; registrations view renders; direct navigation to `/users`, `/finance`, etc. redirects away.

### Screenshots / Screencasts

1. Admin — program dialog with multiple coordinators selected
<img width="453" height="831" alt="Screenshot 2026-06-21 at 4 31 52 PM" src="https://github.com/user-attachments/assets/afc1fe19-c99a-4135-a02d-2ba477579fad" />

2. Coordinator — Overview
<img width="1382" height="721" alt="Screenshot 2026-06-21 at 4 41 35 PM" src="https://github.com/user-attachments/assets/f00ee2fb-af68-4630-b8ee-3f63dc16a565" />

3. Coordinator — Services
<img width="1422" height="732" alt="Screenshot 2026-06-21 at 4 41 46 PM" src="https://github.com/user-attachments/assets/9d35cc79-8cce-4397-88b8-a7c1f66fa705" />

4. Coordinator — Registrations dialog (registrant + form answers)
<img width="596" height="209" alt="Screenshot 2026-06-21 at 4 42 27 PM" src="https://github.com/user-attachments/assets/f26afe19-483a-4b8f-ad26-563d61ea184b" />

5. Coordinator — Scheduled lesson
<img width="1422" height="739" alt="Screenshot 2026-06-21 at 4 41 58 PM" src="https://github.com/user-attachments/assets/9af79ad6-65b1-45f2-aee7-73861e186a84" />


### Checklist
- [x] Code is neat, readable, and works
- [x] Code is commented where appropriate and well-documented
- [x] Commit messages follow our [guidelines](https://www.conventionalcommits.org)
- [x] Issue number is linked
- [x] Branch is linked
- [x] Reviewers are assigned (one of your tech leads)
                                                                                                 
### Notes

- **Sign out access:** sign out for coordinator lives on the Overview card (reachable via the Overview sidebar tab). 
- **Migration drift:** the on-disk migrations on `develop` were already drifted from `schema.ts` (the coach→coordinator rename had been applied to the dev DB via `drizzle-kit push` without a generated migration). Because `drizzle-kit generate` can't resolve renames non-interactively (needs a TTY), `0002` was hand-authored with data-preserving rename DDL plus a snapshot validated by `drizzle-kit check`.
- **Pre-existing, out of scope:** `profiles` columns (`address`, `gender`, `dob`, `phone`) exist in `schema.ts` but were never migrated. Intentionally left out of `0002` to keep it scoped to #88.
